### PR TITLE
Remove intemediate files

### DIFF
--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -575,6 +575,7 @@ namespace CXXGRAPH
 			ifileGraph.ignore(128, '\n');
 		}
 		ifileGraph.close();
+		if (compress) remove(completePathToFileGraph.c_str());
 
 		if (readNodeFeat)
 		{
@@ -597,6 +598,7 @@ namespace CXXGRAPH
 				ifileNodeFeat.ignore(128, '\n');
 			}
 			ifileNodeFeat.close();
+			if (compress) remove(completePathToFileNodeFeat.c_str());
 		}
 
 		if (readEdgeWeight)
@@ -624,6 +626,7 @@ namespace CXXGRAPH
 				ifileEdgeWeight.ignore(128, '\n');
 			}
 			ifileEdgeWeight.close();
+			if (compress) remove(completePathToFileEdgeWeight.c_str());
 		}
 		recreateGraphFromReadFiles(edgeMap, edgeDirectedMap, nodeFeatMap, edgeWeightMap);
 		return 0;
@@ -714,6 +717,7 @@ namespace CXXGRAPH
 			ifileGraph.ignore(128, '\n');
 		}
 		ifileGraph.close();
+		if (compress) remove(completePathToFileGraph.c_str());
 
 		if (readNodeFeat)
 		{
@@ -736,6 +740,7 @@ namespace CXXGRAPH
 				ifileNodeFeat.ignore(128, '\n');
 			}
 			ifileNodeFeat.close();
+			if (compress) remove(completePathToFileNodeFeat.c_str());
 		}
 
 		if (readEdgeWeight)
@@ -763,6 +768,7 @@ namespace CXXGRAPH
 				ifileEdgeWeight.ignore(128, '\n');
 			}
 			ifileEdgeWeight.close();
+			if (compress) remove(completePathToFileEdgeWeight.c_str());
 		}
 		recreateGraphFromReadFiles(edgeMap, edgeDirectedMap, nodeFeatMap, edgeWeightMap);
 		return 0;

--- a/test/RWOutputTest.cpp
+++ b/test/RWOutputTest.cpp
@@ -863,9 +863,6 @@ TEST(RWOutputTest, test_22)
         }
     }
 
-    remove("test_22.csv");
-    remove("test_22_NodeFeat.csv");
-    remove("test_22_EdgeWeight.csv");
     remove("test_22.csv.gz");
     remove("test_22_NodeFeat.csv.gz");
     remove("test_22_EdgeWeight.csv.gz");
@@ -995,9 +992,6 @@ TEST(RWOutputTest, test_25)
         }
     }
 
-    remove("test_25.tsv");
-    remove("test_25_NodeFeat.tsv");
-    remove("test_25_EdgeWeight.tsv");
     remove("test_25.tsv.gz");
     remove("test_25_NodeFeat.tsv.gz");
     remove("test_25_EdgeWeight.tsv.gz");


### PR DESCRIPTION
- resolves https://github.com/ZigRazor/CXXGraph/issues/125
- When reading a compressed file, now it deletes the intermediate uncompressed file extracted by the reading function.
- Removed code in tests that are not needed anymore
