### PR TITLE
replace map with unordered_map

### DIFF
--- a/benchmark/Graph_BM.cpp
+++ b/benchmark/Graph_BM.cpp
@@ -36,7 +36,7 @@ static void AddEdgeX(benchmark::State &state)
     CXXGRAPH::Graph<int> g;
     auto range_start = edges.begin();
     auto range_end = edges.find(state.range(0));
-    std::map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
+    std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
     edgesX.insert(range_start, range_end);
     for (auto _ : state)
     {
@@ -76,7 +76,7 @@ static void AddEdgeX_TS(benchmark::State &state)
     CXXGRAPH::Graph_TS<int> g;
     auto range_start = edges.begin();
     auto range_end = edges.find(state.range(0));
-    std::map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
+    std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
     edgesX.insert(range_start, range_end);
     for (auto _ : state)
     {
@@ -97,7 +97,7 @@ static void BM_AddEdgeX_MT_TS(benchmark::State &state)
     auto subrange = state.range(0) / state.threads();
     auto range_start = edges.find(subrange * state.thread_index());
     auto range_end = edges.find(subrange * (state.thread_index() + 1));
-    std::map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
+    std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
     edgesX.insert(range_start, range_end);
     for (auto _ : state)
     {
@@ -132,7 +132,7 @@ static void RemoveEdgeX(benchmark::State &state)
     CXXGRAPH::Graph<int> g;
     auto range_start = edges.begin();
     auto range_end = edges.find(state.range(0));
-    std::map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
+    std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
     edgesX.insert(range_start, range_end);
     for (auto e : edgesX)
     {
@@ -167,7 +167,7 @@ static void RemoveEdgeX_TS(benchmark::State &state)
     CXXGRAPH::Graph_TS<int> g;
     auto range_start = edges.begin();
     auto range_end = edges.find(state.range(0));
-    std::map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
+    std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
     edgesX.insert(range_start, range_end);
     for (auto e : edgesX)
     {
@@ -193,7 +193,7 @@ static void RemoveEdgeX_MT_TS(benchmark::State &state)
     auto subrange = state.range(0) / state.threads();
     auto range_start = edges.find(subrange * state.thread_index());
     auto range_end = edges.find(subrange * (state.thread_index() + 1));
-    std::map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
+    std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> edgesX;
     edgesX.insert(range_start, range_end);
     for (auto e : edgesX)
     {

--- a/benchmark/Utilities.hpp
+++ b/benchmark/Utilities.hpp
@@ -4,9 +4,9 @@
 #include <time.h>
 #include <stdlib.h>
 
-static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(unsigned long numberOfNodes, int MaxValue)
+static std::unordered_map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(unsigned long numberOfNodes, int MaxValue)
 {
-    std::map<unsigned long, CXXGRAPH::Node<int> *> nodes;
+    std::unordered_map<unsigned long, CXXGRAPH::Node<int> *> nodes;
     srand((unsigned)time(NULL));
     int randomNumber;
     for (auto index = 0; index < numberOfNodes; index++)
@@ -18,9 +18,9 @@ static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(unsign
     return nodes;
 }
 
-static std::map<unsigned long, CXXGRAPH::Edge<int> *> generateRandomEdges(unsigned long numberOfEdges, std::map<unsigned long, CXXGRAPH::Node<int> *> nodes)
+static std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> generateRandomEdges(unsigned long numberOfEdges, std::unordered_map<unsigned long, CXXGRAPH::Node<int> *> nodes)
 {
-    std::map<unsigned long, CXXGRAPH::Edge<int> *> edges;
+    std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> edges;
     srand((unsigned)time(NULL));
     int randomNumber1;
     int randomNumber2;

--- a/include/CXXGraphConfig.h
+++ b/include/CXXGraphConfig.h
@@ -1,0 +1,4 @@
+// the configured options and settings for CXXGraph
+#define CXXGraph_VERSION_MAJOR 0
+#define CXXGraph_VERSION_MINOR 2
+#define CXXGraph_VERSION_PATCH 0

--- a/include/CXXGraphConfig.h
+++ b/include/CXXGraphConfig.h
@@ -1,4 +1,0 @@
-// the configured options and settings for CXXGraph
-#define CXXGraph_VERSION_MAJOR 0
-#define CXXGraph_VERSION_MINOR 2
-#define CXXGraph_VERSION_PATCH 0

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -83,7 +83,7 @@ namespace CXXGRAPH
 		int readFromStandardFile_csv(const std::string &workingDir, const std::string &OFileName, bool compress, bool readNodeFeat, bool readEdgeWeight);
 		int writeToStandardFile_tsv(const std::string &workingDir, const std::string &OFileName, bool compress, bool writeNodeFeat, bool writeEdgeWeight) const;
 		int readFromStandardFile_tsv(const std::string &workingDir, const std::string &OFileName, bool compress, bool readNodeFeat, bool readEdgeWeight);
-		void recreateGraphFromReadFiles(std::map<unsigned long long, std::pair<unsigned long long, unsigned long long>> &edgeMap, std::map<unsigned long long, bool> &edgeDirectedMap, std::map<unsigned long long, T> &nodeFeatMap, std::map<unsigned long long, double> &edgeWeightMap);
+		void recreateGraphFromReadFiles(std::unordered_map<unsigned long long, std::pair<unsigned long long, unsigned long long>> &edgeMap, std::unordered_map<unsigned long long, bool> &edgeDirectedMap, std::unordered_map<unsigned long long, T> &nodeFeatMap, std::unordered_map<unsigned long long, double> &edgeWeightMap);
 		int compressFile(const std::string &inputFile, const std::string &outputFile) const;
 		int decompressFile(const std::string &inputFile, const std::string &outputFile) const;
 
@@ -161,7 +161,7 @@ namespace CXXGRAPH
  		* @return parent node of elem 
 		* Note: No Thread Safe
 		*/
-		virtual unsigned long long setFind(std::map<unsigned long long, Subset>* , const unsigned long long elem) const;
+		virtual unsigned long long setFind(std::unordered_map<unsigned long long, Subset>* , const unsigned long long elem) const;
 		/**
 		* @brief This function modifies the original subset array
 		* such that it the union of two sets a and b
@@ -171,7 +171,7 @@ namespace CXXGRAPH
  		* NOTE: Original subset is no longer available after union.
 		* Note: No Thread Safe
 		*/
-		virtual void setUnion(std::map<unsigned long long, Subset>* , const unsigned long long set1, const unsigned long long elem2) const;		
+		virtual void setUnion(std::unordered_map<unsigned long long, Subset>* , const unsigned long long set1, const unsigned long long elem2) const;		
 		/**
 		* @brief This function finds the eulerian path of a directed graph using hierholzers algorithm
  		*
@@ -301,7 +301,7 @@ namespace CXXGRAPH
 		 * 
 		 * @return true if a cycle is detected, else false
 		 */
-		virtual bool containsCycle(const std::list<const Edge<T>* >* edgeSet, std::map<unsigned long long, Subset>*) const;
+		virtual bool containsCycle(const std::list<const Edge<T>* >* edgeSet, std::unordered_map<unsigned long long, Subset>*) const;
 
 		/**
      	* \brief
@@ -569,10 +569,10 @@ namespace CXXGRAPH
 		std::ifstream ifileGraph;
 		std::ifstream ifileNodeFeat;
 		std::ifstream ifileEdgeWeight;
-		std::map<unsigned long long, std::pair<unsigned long long, unsigned long long>> edgeMap;
-		std::map<unsigned long long, bool> edgeDirectedMap;
-		std::map<unsigned long long, T> nodeFeatMap;
-		std::map<unsigned long long, double> edgeWeightMap;
+		std::unordered_map<unsigned long long, std::pair<unsigned long long, unsigned long long>> edgeMap;
+		std::unordered_map<unsigned long long, bool> edgeDirectedMap;
+		std::unordered_map<unsigned long long, T> nodeFeatMap;
+		std::unordered_map<unsigned long long, double> edgeWeightMap;
 		std::string completePathToFileGraph = workingDir + "/" + OFileName + ".csv";
 		ifileGraph.open(completePathToFileGraph);
 		if (!ifileGraph.is_open())
@@ -712,10 +712,10 @@ namespace CXXGRAPH
 		std::ifstream ifileGraph;
 		std::ifstream ifileNodeFeat;
 		std::ifstream ifileEdgeWeight;
-		std::map<unsigned long long, std::pair<unsigned long long, unsigned long long>> edgeMap;
-		std::map<unsigned long long, bool> edgeDirectedMap;
-		std::map<unsigned long long, T> nodeFeatMap;
-		std::map<unsigned long long, double> edgeWeightMap;
+		std::unordered_map<unsigned long long, std::pair<unsigned long long, unsigned long long>> edgeMap;
+		std::unordered_map<unsigned long long, bool> edgeDirectedMap;
+		std::unordered_map<unsigned long long, T> nodeFeatMap;
+		std::unordered_map<unsigned long long, double> edgeWeightMap;
 		std::string completePathToFileGraph = workingDir + "/" + OFileName + ".tsv";
 		ifileGraph.open(completePathToFileGraph);
 		if (!ifileGraph.is_open())
@@ -795,9 +795,9 @@ namespace CXXGRAPH
 	}
 
 	template <typename T>
-	void Graph<T>::recreateGraphFromReadFiles(std::map<unsigned long long, std::pair<unsigned long long, unsigned long long>> &edgeMap, std::map<unsigned long long, bool> &edgeDirectedMap, std::map<unsigned long long, T> &nodeFeatMap, std::map<unsigned long long, double> &edgeWeightMap)
+	void Graph<T>::recreateGraphFromReadFiles(std::unordered_map<unsigned long long, std::pair<unsigned long long, unsigned long long>> &edgeMap, std::unordered_map<unsigned long long, bool> &edgeDirectedMap, std::unordered_map<unsigned long long, T> &nodeFeatMap, std::unordered_map<unsigned long long, double> &edgeWeightMap)
 	{
-		std::map<unsigned long long, Node<T> *> nodeMap;
+		std::unordered_map<unsigned long long, Node<T> *> nodeMap;
 		for (const auto& edgeIt : edgeMap)
 		{
 			Node<T> *node1 = nullptr;
@@ -935,7 +935,7 @@ namespace CXXGRAPH
 	}
 
 	template <typename T>
-	unsigned long long Graph<T>::setFind(std::map<unsigned long long, Subset> *subsets, const unsigned long long nodeId) const
+	unsigned long long Graph<T>::setFind(std::unordered_map<unsigned long long, Subset> *subsets, const unsigned long long nodeId) const
 	{
 		// find root and make root as parent of i
 		// (path compression)
@@ -948,7 +948,7 @@ namespace CXXGRAPH
 	}
 
 	template <typename T>
-	void Graph<T>::setUnion(std::map<unsigned long long, Subset>* subsets, const unsigned long long elem1, const unsigned long long elem2) const
+	void Graph<T>::setUnion(std::unordered_map<unsigned long long, Subset>* subsets, const unsigned long long elem1, const unsigned long long elem2) const
 	{
 		// if both sets have same parent
 		// then there's nothing to be done
@@ -1050,7 +1050,7 @@ namespace CXXGRAPH
 		int n = adj.size();
 
 		// setting all the distances initially to INF_DOUBLE
-		std::map<const Node<T> *, double> dist;
+		std::unordered_map<const Node<T> *, double> dist;
 
 		for (const auto& elem : adj)
 		{
@@ -1156,7 +1156,7 @@ namespace CXXGRAPH
 			return result;
 		}
 		// setting all the distances initially to INF_DOUBLE
-		std::map<const Node<T> *, double> dist, currentDist;
+		std::unordered_map<const Node<T> *, double> dist, currentDist;
 		// n denotes the number of vertices in graph
 		auto n = nodeSet.size();
 		for (const auto& elem : nodeSet)
@@ -1247,7 +1247,7 @@ namespace CXXGRAPH
 		FWResult result;
 		result.success = false;
 		result.errorMessage = "";
-		std::map<std::pair<std::string, std::string>, double> pairwise_dist;
+		std::unordered_map<std::pair<std::string, std::string>, double, CXXGRAPH::pair_hash> pairwise_dist;
 		auto nodeSet = Graph<T>::getNodeSet();
 		// create a pairwise distance matrix with distance node distances
 		// set to inf. Distance of node to itself is set as 0.
@@ -1338,7 +1338,7 @@ namespace CXXGRAPH
 		const AdjacencyMatrix<T> adj = Graph<T>::getAdjMatrix();
 
 		// setting all the distances initially to INF_DOUBLE
-		std::map<const Node<T> *, double> dist;
+		std::unordered_map<const Node<T> *, double> dist;
 		for (const auto& elem : adj)
 		{
 			dist[elem.first] = INF_DOUBLE;
@@ -1361,7 +1361,7 @@ namespace CXXGRAPH
 		doneNode.push_back(source->getId());
 		// stores the parent and corresponding child node
 		// of the edges that are part of MST
-		std::map<unsigned long long, std::string> parentNode;
+		std::unordered_map<unsigned long long, std::string> parentNode;
 		while (!pq.empty())
 		{
 			// second element of pair denotes the node / vertex
@@ -1424,7 +1424,7 @@ namespace CXXGRAPH
 		const auto n = nodeSet.size();
 
 		// Use std map for storing n subsets.
-		std::map<unsigned long long, Subset> subsets;
+		std::unordered_map<unsigned long long, Subset> subsets;
 
 		// Initially there are n different trees.
 		// Finally there will be one tree that will be MST
@@ -1433,7 +1433,7 @@ namespace CXXGRAPH
 		// check if all edges are weighted and store the weights
 		// in a map whose keys are the edge ids and values are the edge weights
 		const auto edgeSet = Graph<T>::getEdgeSet();
-		std::map<unsigned long long, double> edgeWeight;
+		std::unordered_map<unsigned long long, double> edgeWeight;
 		for (const auto& edge : edgeSet)
 		{
 			if (edge->isWeighted().has_value() && edge->isWeighted().value())
@@ -1458,7 +1458,7 @@ namespace CXXGRAPH
 		{
 			// Everytime initialize cheapest map
 			// It stores index of the cheapest edge of subset.
-			std::map<unsigned long long, unsigned long long> cheapest;
+			std::unordered_map<unsigned long long, unsigned long long> cheapest;
 			for (const auto& node : nodeSet)
 				cheapest[node->getId()] = INT_MAX;
 
@@ -1549,7 +1549,7 @@ namespace CXXGRAPH
 			}
 		}
 
-		std::map<unsigned long long, Subset> subset;
+		std::unordered_map<unsigned long long, Subset> subset;
 
 		for (const auto& node : nodeSet)
 		{
@@ -1670,7 +1670,7 @@ namespace CXXGRAPH
          *
          * Initially, all nodes are in "not_visited" state.
          */
-		std::map<unsigned long long, nodeStates> state;
+		std::unordered_map<unsigned long long, nodeStates> state;
 		for (const auto& node : nodeSet)
 		{
 			state[node->getId()] = not_visited;
@@ -1686,8 +1686,8 @@ namespace CXXGRAPH
 			if (state[node->getId()] == not_visited)
 			{
 				// Check for cycle.
-				std::function<bool(AdjacencyMatrix<T> &, std::map<unsigned long long, nodeStates> &, const Node<T> *)> isCyclicDFSHelper;
-				isCyclicDFSHelper = [this, &isCyclicDFSHelper](AdjacencyMatrix<T> &adjMatrix, std::map<unsigned long long, nodeStates> &states, const Node<T> *node)
+				std::function<bool(AdjacencyMatrix<T> &, std::unordered_map<unsigned long long, nodeStates> &, const Node<T> *)> isCyclicDFSHelper;
+				isCyclicDFSHelper = [this, &isCyclicDFSHelper](AdjacencyMatrix<T> &adjMatrix, std::unordered_map<unsigned long long, nodeStates> &states, const Node<T> *node)
 				{
 					// Add node "in_stack" state.
 					states[node->getId()] = in_stack;
@@ -1740,7 +1740,7 @@ namespace CXXGRAPH
 	template <typename T>
 	bool Graph<T>::containsCycle(const std::list<const Edge<T>* >* edgeSet) const
 	{
-		std::map<unsigned long long, Subset> subset;
+		std::unordered_map<unsigned long long, Subset> subset;
 		// initialize the subset parent and rank values
 		for (const auto& edge: *edgeSet)
 		{	
@@ -1766,7 +1766,7 @@ namespace CXXGRAPH
 	}
 
 	template <typename T>
-	bool Graph<T>::containsCycle(const std::list<const Edge<T>* >* edgeSet, std::map<unsigned long long, Subset>* subset) const
+	bool Graph<T>::containsCycle(const std::list<const Edge<T>* >* edgeSet, std::unordered_map<unsigned long long, Subset>* subset) const
 	{		
 		for (const auto& edge: *edgeSet)
 		{			
@@ -1790,7 +1790,7 @@ namespace CXXGRAPH
 		auto adjMatrix = Graph<T>::getAdjMatrix();
 		auto nodeSet = Graph<T>::getNodeSet();
 
-		std::map<unsigned long, unsigned int> indegree;
+		std::unordered_map<unsigned long, unsigned int> indegree;
 		for (const auto& node : nodeSet)
 		{
 			indegree[node->getId()] = 0;
@@ -1902,7 +1902,7 @@ namespace CXXGRAPH
     		dist[i].first = distance of ith vertex from src vertex
     		dits[i].second = vertex i in bucket number */
 		unsigned int V = nodeSet.size();
-		std::map<const Node<T> *, std::pair<long, const Node<T> *>> dist;
+		std::unordered_map<const Node<T> *, std::pair<long, const Node<T> *>> dist;
 
 		// Initialize all distances as infinite (INF)
 		for (const auto& node : nodeSet)

--- a/include/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/Partitioning/CoordinatedPartitionState.hpp
@@ -39,7 +39,7 @@ namespace CXXGRAPH
         class CoordinatedPartitionState : public PartitionState<T>
         {
         private:
-            std::map<int, CoordinatedRecord<T>> record_map = {};
+            std::unordered_map<int, CoordinatedRecord<T>> record_map = {};
             std::vector<int> machines_load_edges = {};
             std::vector<int> machines_load_vertices = {};
             PartitionMap<T> partition_map;

--- a/include/Utility/Typedef.hpp
+++ b/include/Utility/Typedef.hpp
@@ -84,13 +84,34 @@ namespace CXXGRAPH
 	};
 	typedef BellmanFordResult_struct BellmanFordResult;
 
+	// implmentation is similar to boost hash_combine
+	template<typename T> 
+	inline T hash_combine(T& lhs, const T& rhs) {
+	    T result = lhs ^ (rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2));
+		return result;
+	}
+
+	/// The C++ Standard doesn't provide a hash for std::pair type, which is required when 
+	/// using std::pair as a key in std::unordered_map. So, hash function for pair needs to 
+	/// be provided.
+	/// Hash for a pair is calculated by calcuating hash for individual elements and then 
+	/// combining. For combining, an implmentation similar to boost hash_combine is implemented.
+	struct pair_hash {
+    template <class T1, class T2>
+    std::size_t operator () (const std::pair<T1,T2> &p) const {
+        std::size_t h1 = std::hash<T1>{}(p.first);
+        std::size_t h2 = std::hash<T2>{}(p.second);
+				return hash_combine(h1, h2);
+    }
+	};
+
 	/// Struct that contains the information about Floyd-Warshall Algorithm results
 	struct FWResult_struct
 	{
 		bool success = false;			  // TRUE if the function does not return error, FALSE otherwise
 		bool negativeCycle = false;		  // TRUE if graph contains a negative cycle, FALSE otherwise
 		std::string errorMessage = ""; //message of error
-		std::map<std::pair<std::string, std::string>, double> result = {};
+		std::unordered_map<std::pair<std::string, std::string>, double, pair_hash> result = {};
 	};
 	typedef FWResult_struct FWResult;
 	
@@ -109,7 +130,7 @@ namespace CXXGRAPH
 	{
 		bool success = false;								  // TRUE if the function does not return error, FALSE otherwise
 		std::string errorMessage = "";					  //message of error
-		std::map<unsigned long long, long> minDistanceMap = {}; //result a map that contains the node id and the minumum distance from source (valid only if success is TRUE)
+		std::unordered_map<unsigned long long, long> minDistanceMap = {}; //result a map that contains the node id and the minumum distance from source (valid only if success is TRUE)
 	};
 	typedef DialResult_struct DialResult;
 
@@ -120,10 +141,10 @@ namespace CXXGRAPH
     // Using Definition ///////////////////////////////////////////////////////////////
 
 	template <typename T>
-	using AdjacencyMatrix = std::map<const Node<T> *, std::vector<std::pair<const Node<T> *, const Edge<T> *>>>;
+	using AdjacencyMatrix = std::unordered_map<const Node<T> *, std::vector<std::pair<const Node<T> *, const Edge<T> *>>>;
 
 	template <typename T>
-	using PartitionMap = std::map<unsigned int, PARTITIONING::Partition<T> *>;
+	using PartitionMap = std::unordered_map<unsigned int, PARTITIONING::Partition<T> *>;
 
 	///////////////////////////////////////////////////////////////////////////////////	
 }

--- a/test/FWTest.cpp
+++ b/test/FWTest.cpp
@@ -26,7 +26,7 @@ TEST(FWTest, test_1)
     CXXGRAPH::Graph<int> graph(edgeSet);
     CXXGRAPH::FWResult res = graph.floydWarshall();
 
-    std::map<std::pair<std::string, std::string>, double> pairwise_dist;
+    std::unordered_map<std::pair<std::string, std::string>, double, CXXGRAPH::pair_hash> pairwise_dist;
     auto key = std::make_pair(node1.getUserId(), node1.getUserId());
     auto nodeSet = graph.getNodeSet();
     double values[4][4] = {{0, -1, -2, 0}, {4, 0, 2, 4}, {5, 1, 0, 2}, {3, -1, 1, 0}};

--- a/test/NodeTest.cpp
+++ b/test/NodeTest.cpp
@@ -36,7 +36,7 @@ TEST(StringNodeTest, StringConstructor)
     char charTest = 'w';
     std::string stringTest = "myStr";
     std::vector<int> vectorTest = {1,2,3,4};
-    std::map<int,int> mapTest = {{1,2},{3,4},{5,6},{7,8}};
+    std::unordered_map<int,int> mapTest = {{1,2},{3,4},{5,6},{7,8}};
     testStruct structTest(42, true, "abc");
 
     CXXGRAPH::Node<int> intNode("1", intTest);
@@ -46,7 +46,7 @@ TEST(StringNodeTest, StringConstructor)
     CXXGRAPH::Node<char> charNode("5", charTest);
     CXXGRAPH::Node<std::string> stringNode("6", stringTest);
     CXXGRAPH::Node<std::vector<int>> vectorNode("7", vectorTest);
-    CXXGRAPH::Node<std::map<int,int>> mapNode("8", mapTest);
+    CXXGRAPH::Node<std::unordered_map<int,int>> mapNode("8", mapTest);
     CXXGRAPH::Node<testStruct> structNode("9", structTest);
 
     ASSERT_EQ(intNode.getUserId(), "1");

--- a/test/RWOutputTest.cpp
+++ b/test/RWOutputTest.cpp
@@ -8,9 +8,9 @@ inline bool exists_test(const std::string &name)
     return (stat(name.c_str(), &buffer) == 0);
 }
 
-static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(unsigned long numberOfNodes, int MaxValue)
+static std::unordered_map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(unsigned long numberOfNodes, int MaxValue)
 {
-    std::map<unsigned long, CXXGRAPH::Node<int> *> nodes;
+    std::unordered_map<unsigned long, CXXGRAPH::Node<int> *> nodes;
     srand(static_cast<unsigned>(time(NULL)));
     int randomNumber;
     for (auto index = 0; index < numberOfNodes; ++index)
@@ -23,9 +23,9 @@ static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(unsign
     return nodes;
 }
 
-static std::map<unsigned long, CXXGRAPH::Edge<int> *> generateRandomEdges(unsigned long numberOfEdges, std::map<unsigned long, CXXGRAPH::Node<int> *> nodes)
+static std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> generateRandomEdges(unsigned long numberOfEdges, std::unordered_map<unsigned long, CXXGRAPH::Node<int> *> nodes)
 {
-    std::map<unsigned long, CXXGRAPH::Edge<int> *> edges;
+    std::unordered_map<unsigned long, CXXGRAPH::Edge<int> *> edges;
     srand(static_cast<unsigned>(time(NULL)));
     int randomNumber1;
     int randomNumber2;

--- a/test/UnionFindTest.cpp
+++ b/test/UnionFindTest.cpp
@@ -25,7 +25,7 @@ TEST(UnionFindTest, setFindTest1)
     CXXGRAPH::Graph<int> graph(edgeSet);
 
     // every element is a subset of itself
-    std::map<unsigned long long, CXXGRAPH::Subset> subset;
+    std::unordered_map<unsigned long long, CXXGRAPH::Subset> subset;
     // {{0, 0}, {1, 0}, {2, 0}, {3, 0}};
     CXXGRAPH::Subset set1{0, 0}, set2{1, 0}, set3{2, 0}, set4{3, 0};
     subset = { {0, set1}, {1, set2}, {2, set3}, {3, set4}};
@@ -46,7 +46,7 @@ TEST(UnionFindTest, setFindTest2)
     CXXGRAPH::Node<int> node3("3", 3);
     // element 2 & 4 are subset of 0
     // element 4 is subset of 1
-    std::map<unsigned long long, CXXGRAPH::Subset> subset;
+    std::unordered_map<unsigned long long, CXXGRAPH::Subset> subset;
     CXXGRAPH::Subset set1{0, 0}, set2{0, 0}, set3{0, 0}, set4{1, 0};
     subset = { {0, set1}, {1, set2}, {2, set3}, {3, set4}};
 
@@ -70,7 +70,7 @@ TEST(UnionFindTest, setUnionTest3)
     CXXGRAPH::Node<int> node2("2", 2);
     CXXGRAPH::Node<int> node3("3", 3);
     // union of (node 1 & node3)  should increase node0 rank by 1
-    std::map<unsigned long long, CXXGRAPH::Subset> subset;
+    std::unordered_map<unsigned long long, CXXGRAPH::Subset> subset;
     CXXGRAPH::Subset set1{0, 0}, set2{0, 0}, set3{0, 0}, set4{1, 0};
     subset = { {0, set1}, {1, set2}, {2, set3}, {3, set4}};
 


### PR DESCRIPTION
Resolves Use Unordered_map instead of map #157
Replaced all the instances of map with unordered_map. For instances of unordered_map where key is a std::pair, an implementation to calculate hash has been provided.