### PR TITLE
Refactoring: writeToStandardFile and readFromStandardFile

### DIFF
--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -80,18 +80,8 @@ namespace CXXGRAPH
 		std::list<const Edge<T> *> edgeSet = {};
 		void addElementToAdjMatrix(AdjacencyMatrix<T> &adjMatrix, const Node<T> *nodeFrom, const Node<T> *nodeTo, const Edge<T> *edge) const;
 		std::optional<std::pair<std::string, char>> getExtenstionAndSeparator(InputOutputFormat format) const;
-		int writeToStandardFile(const std::string &workingDir, 
-		                        const std::string &OFileName, 
-								bool compress, 
-								bool writeNodeFeat, 
-								bool writeEdgeWeight,
-								InputOutputFormat format) const;
-		int readFromStandardFile(const std::string &workingDir, 
-		                         const std::string &OFileName, 
-								 bool compress, 
-								 bool readNodeFeat, 
-								 bool readEdgeWeight, 
-								 InputOutputFormat format);
+		int writeToStandardFile(const std::string &workingDir, const std::string &OFileName, bool compress, bool writeNodeFeat, bool writeEdgeWeight, InputOutputFormat format) const;
+		int readFromStandardFile(const std::string &workingDir, const std::string &OFileName, bool compress, bool readNodeFeat, bool readEdgeWeight, InputOutputFormat format);
 		void recreateGraphFromReadFiles(std::unordered_map<unsigned long long, std::pair<unsigned long long, unsigned long long>> &edgeMap, std::unordered_map<unsigned long long, bool> &edgeDirectedMap, std::unordered_map<unsigned long long, T> &nodeFeatMap, std::unordered_map<unsigned long long, double> &edgeWeightMap);
 		int compressFile(const std::string &inputFile, const std::string &outputFile) const;
 		int decompressFile(const std::string &inputFile, const std::string &outputFile) const;
@@ -530,12 +520,7 @@ namespace CXXGRAPH
 	}
 
 	template <typename T>
-	int Graph<T>::writeToStandardFile(const std::string &workingDir, 
-													          const std::string &OFileName, 
-																		bool compress, 
-																		bool writeNodeFeat, 
-																		bool writeEdgeWeight,
-																		InputOutputFormat format) const
+	int Graph<T>::writeToStandardFile(const std::string &workingDir, const std::string &OFileName, bool compress, bool writeNodeFeat, bool writeEdgeWeight, InputOutputFormat format) const
 	{
 		auto result = getExtenstionAndSeparator(format);
 		if (!result) {
@@ -616,12 +601,7 @@ namespace CXXGRAPH
 	};
 
 	template <typename T>
-	int Graph<T>::readFromStandardFile( const std::string &workingDir, 
-									    const std::string &OFileName, 
-										bool compress, 
-										bool readNodeFeat, 
-										bool readEdgeWeight,
-										InputOutputFormat format) 
+	int Graph<T>::readFromStandardFile( const std::string &workingDir, const std::string &OFileName, bool compress, bool readNodeFeat, bool readEdgeWeight, InputOutputFormat format) 
 	{
 		auto result = getExtenstionAndSeparator(format);
 		if (!result) {

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -680,8 +680,6 @@ namespace CXXGRAPH
 					// convert from string to respective data type based on T
 					if constexpr (std::is_same_v<T, std::string>) {
 						nodeFeat = tokens[1];
-					} else if constexpr (std::is_same_v<T, int>) {
-						nodeFeat = std::stoi(tokens[1]);
 					} else if constexpr (std::is_same_v<T, long>) {
 						nodeFeat = std::stol(tokens[1]);
 					} else if constexpr (std::is_same_v<T, long long>) {


### PR DESCRIPTION
Resolves Refactoring: writeToStandardFile_tsv and writeToStandardFile_csv #168
- The readFromStandardFile_csv and readFromStandardFile_tsv is replaced with readFromStandardFile() with an additional parameter of type InputOutputFormat. 
- The writeToStandardFile_csv and writeToStandardFile_tsv is replaced with writeToStandardFile() with an additional parameter of type InputOutputFormat.

@ZigRazor @AlfredCP @sidml 



