### PR TITLE
Fix errors causing some tests in PartitionTest to fail.

### DIFF
--- a/include/Partitioning/Partitioner.hpp
+++ b/include/Partitioning/Partitioner.hpp
@@ -119,7 +119,9 @@ namespace CXXGRAPH
             }
             for (int t = 0; t < processors; ++t)
             {
-                myThreads[t].join();
+                if (myThreads[t].joinable()){
+                    myThreads[t].join();
+                }
             }
             return state;
         }


### PR DESCRIPTION
When trying to call join() on threads in Partitioner::startCoordinated() C++ will sometimes throw an invalid_argument exception as some of or all of the threads might be default constructed and therefore not joinable. This happens because the threads are only assigned a function if a given condition is met. This PR fixes this by checking if a thread is joinable before calling join() on the thread, which subsequently fixes and passes PartitionTest.test_1, PartitionTest.test_3, PartitionTest.test_5 and PartitionTest.test_7.