### PR TITLE
Implement the truly "Header only" version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,39 +40,42 @@ if(CODE_COVERAGE)
 endif(CODE_COVERAGE)
 
 # add the library
+option(WITH_GTEST "Add GTest for testing." OFF)
+if (WITH_GTEST)
+	file (GLOB TEST_FILES "test/*.cpp" "test/*.hpp")
 
-file (GLOB TEST_FILES "test/*.cpp" "test/*.hpp")
+	add_executable(test_exe ${TEST_FILES})
 
-add_executable(test_exe ${TEST_FILES})
-
-target_include_directories(test_exe PUBLIC
-						  "${PROJECT_SOURCE_DIR}/include"
-						  )
-target_link_libraries(test_exe
-					   libgtest.a
-					   libgtest_main.a
-					   pthread
-					   ssl
-					   crypto
-					   z)
+	target_include_directories(test_exe PUBLIC
+			"${PROJECT_SOURCE_DIR}/include"
+			)
+	target_link_libraries(test_exe
+			libgtest.a
+			libgtest_main.a
+			pthread
+			ssl
+			crypto
+			z)
 
 
-enable_testing()
+	enable_testing()
 
-add_test(test_node test_exe --gtest_filter=NodeTest*)
-add_test(test_edge test_exe --gtest_filter=EdgeTest*)
-add_test(test_directededge test_exe --gtest_filter=DirectedEdgeTest*)
-add_test(test_undirectededge test_exe --gtest_filter=UndirectedEdgeTest*)
-add_test(test_directedweightededge test_exe --gtest_filter=DirectedWeightedEdgeTest*)
-add_test(test_undirectedweightededge test_exe --gtest_filter=UndirectedWeightedEdgeTest*)
-add_test(test_graph test_exe --gtest_filter=GraphTest*)
-add_test(test_dijkstra test_exe --gtest_filter=DijkstraTest*)
-add_test(test_bfs test_exe --gtest_filter=BFSTest*)
-add_test(test_dfs test_exe --gtest_filter=DFSTest*)
-add_test(test_cycle_check test_exe --gtest_filter=CycleCheckTest*)
-add_test(test_rw_output test_exe --gtest_filter=RWOutputTest*)
-add_test(test_partition test_exe --gtest_filter=PartitionTest*)
-add_test(test_dial test_exe --gtest_filter=DialTest*)
+	add_test(test_node test_exe --gtest_filter=NodeTest*)
+	add_test(test_edge test_exe --gtest_filter=EdgeTest*)
+	add_test(test_directededge test_exe --gtest_filter=DirectedEdgeTest*)
+	add_test(test_undirectededge test_exe --gtest_filter=UndirectedEdgeTest*)
+	add_test(test_directedweightededge test_exe --gtest_filter=DirectedWeightedEdgeTest*)
+	add_test(test_undirectedweightededge test_exe --gtest_filter=UndirectedWeightedEdgeTest*)
+	add_test(test_graph test_exe --gtest_filter=GraphTest*)
+	add_test(test_dijkstra test_exe --gtest_filter=DijkstraTest*)
+	add_test(test_bfs test_exe --gtest_filter=BFSTest*)
+	add_test(test_dfs test_exe --gtest_filter=DFSTest*)
+	add_test(test_cycle_check test_exe --gtest_filter=CycleCheckTest*)
+	add_test(test_rw_output test_exe --gtest_filter=RWOutputTest*)
+	add_test(test_partition test_exe --gtest_filter=PartitionTest*)
+	add_test(test_dial test_exe --gtest_filter=DialTest*)
+
+endif ()
 
 option(BENCHMARK "Enable Benchmark" OFF)
 if(BENCHMARK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.9)
 # set the project name and version
 project(CXXGraph VERSION 0.3.0)
 
-configure_file(CXXGraphConfig.h.in ${PROJECT_SOURCE_DIR}/include/CXXGraphConfig.h)
+configure_file(CXXGraph.hpp.in ${PROJECT_SOURCE_DIR}/include/CXXGraph.hpp)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,4 +94,8 @@ if(BENCHMARK)
 					   z)
 endif(BENCHMARK)
 
-install(FILES include/Graph.hpp DESTINATION /usr/include)
+if(BENCHMARK OR WITH_GTEST)
+	add_compile_definitions(WITH_COMPRESSION)
+endif()
+
+install(DIRECTORY include/ DESTINATION /usr/include/CXXGraph/)

--- a/CXXGraph.hpp.in
+++ b/CXXGraph.hpp.in
@@ -2,9 +2,9 @@
 #define __CXXGRAPH_H__
 
 // the configured options and settings for CXXGraph
-#define CXXGraph_VERSION_MAJOR 0
-#define CXXGraph_VERSION_MINOR 3
-#define CXXGraph_VERSION_PATCH 0
+#define CXXGraph_VERSION_MAJOR @CXXGraph_VERSION_MAJOR@
+#define CXXGraph_VERSION_MINOR @CXXGraph_VERSION_MINOR@
+#define CXXGraph_VERSION_PATCH @CXXGraph_VERSION_PATCH@
 
 #include "Edge/Edge.hpp"
 #include "Edge/DirectedEdge.hpp"

--- a/CXXGraphConfig.h.in
+++ b/CXXGraphConfig.h.in
@@ -1,4 +1,0 @@
-// the configured options and settings for CXXGraph
-#define CXXGraph_VERSION_MAJOR @CXXGraph_VERSION_MAJOR@
-#define CXXGraph_VERSION_MINOR @CXXGraph_VERSION_MINOR@
-#define CXXGraph_VERSION_PATCH @CXXGraph_VERSION_PATCH@

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -84,8 +84,11 @@ namespace CXXGRAPH
 		int writeToStandardFile(const std::string &workingDir, const std::string &OFileName, bool compress, bool writeNodeFeat, bool writeEdgeWeight, InputOutputFormat format) const;
 		int readFromStandardFile(const std::string &workingDir, const std::string &OFileName, bool compress, bool readNodeFeat, bool readEdgeWeight, InputOutputFormat format);
 		void recreateGraphFromReadFiles(std::unordered_map<unsigned long long, std::pair<std::string, std::string>> &edgeMap, std::unordered_map<unsigned long long, bool> &edgeDirectedMap, std::unordered_map<std::string, T> &nodeFeatMap, std::unordered_map<unsigned long long, double> &edgeWeightMap);
+
+#ifdef WITH_COMPRESSION
 		int compressFile(const std::string &inputFile, const std::string &outputFile) const;
 		int decompressFile(const std::string &inputFile, const std::string &outputFile) const;
+#endif
 
 	public:
 		Graph() = default;
@@ -813,7 +816,7 @@ namespace CXXGRAPH
 			}
 		}
 	}
-
+#ifdef WITH_COMPRESSION
 	template <typename T>
 	int Graph<T>::compressFile(const std::string &inputFile, const std::string &outputFile) const
 	{
@@ -883,6 +886,7 @@ namespace CXXGRAPH
 		gzclose(inFileZ);
 		return 0;
 	}
+#endif
 
 	template <typename T>
 	unsigned long long Graph<T>::setFind(std::unordered_map<unsigned long long, Subset> *subsets, const unsigned long long nodeId) const
@@ -2186,7 +2190,7 @@ namespace CXXGRAPH
 		}
 		return result;
 	}
-
+#ifdef WITH_COMPRESSION
 	template <typename T>
 	int Graph<T>::writeToFile(InputOutputFormat format, const std::string &workingDir, const std::string &OFileName, bool compress, bool writeNodeFeat, bool writeEdgeWeight) const
 	{
@@ -2299,6 +2303,7 @@ namespace CXXGRAPH
 		}
 		return result;
 	}
+#endif
 
 	template <typename T>
 	PartitionMap<T> Graph<T>::partitionGraph(PARTITIONING::PartitionAlgorithm algorithm, unsigned int numberOfPartitions, double param1, double param2, double param3, unsigned int numberOfthreads) const


### PR DESCRIPTION
- Remove CXXGraphConfig.h.in dependency.
- Set a flag to Enable/Disable Gtests (off by default)
- Remove the zlib dependency unless you are using GTests or Benchmark, and set the installation path of CXXGraph into /usr/include/CXXGraph

This commit should close the Issue #209.
Waiting @ZigRazor to review the incoming changes.

