### PR TITLE
Improved return type for Kosaraju's algoritm + tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,12 @@ add_test(test_cycle_check test_exe --gtest_filter=CycleCheckTest*)
 add_test(test_rw_output test_exe --gtest_filter=RWOutputTest*)
 add_test(test_partition test_exe --gtest_filter=PartitionTest*)
 add_test(test_dial test_exe --gtest_filter=DialTest*)
+<<<<<<< HEAD
+add_test(test_kosaraju test_exe --gtest_filter=TestKosaraju*)
+=======
 add_test(test_bestfirstsearch test_exe --gtest_filter=BestFirstSearch*)
 add_test(test_kahn test_exe --gtest_filter=Kahn*)
+>>>>>>> 9c05b354549f97b5c29431dbae605d4664348fd0
 
 option(BENCHMARK "Enable Benchmark" OFF)
 if(BENCHMARK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,9 @@ add_test(test_cycle_check test_exe --gtest_filter=CycleCheckTest*)
 add_test(test_rw_output test_exe --gtest_filter=RWOutputTest*)
 add_test(test_partition test_exe --gtest_filter=PartitionTest*)
 add_test(test_dial test_exe --gtest_filter=DialTest*)
-<<<<<<< HEAD
 add_test(test_kosaraju test_exe --gtest_filter=TestKosaraju*)
-=======
 add_test(test_bestfirstsearch test_exe --gtest_filter=BestFirstSearch*)
 add_test(test_kahn test_exe --gtest_filter=Kahn*)
->>>>>>> 9c05b354549f97b5c29431dbae605d4664348fd0
 
 option(BENCHMARK "Enable Benchmark" OFF)
 if(BENCHMARK)

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -405,7 +405,7 @@ namespace CXXGRAPH
 		* Note: No Thread Safe
 		* @return a vector of vector of strongly connected components.
 		*/
-		virtual std::vector<std::vector<Node<T>>> kosaraju() const;
+		virtual SCCResult<T> kosaraju() const;
 
 		/**
 		* \brief
@@ -2316,6 +2316,9 @@ namespace CXXGRAPH
     }
 
 	template <typename T>
+<<<<<<< HEAD
+        SCCResult<T> Graph<T>::kosaraju() const
+=======
 	TopoSortResult<T> Graph<T>::kahn() const
 	{
 		TopoSortResult<T> result;
@@ -2390,12 +2393,15 @@ namespace CXXGRAPH
 
 	template <typename T>
 	std::vector<std::vector<Node<T>>> Graph<T>::kosaraju() const
+>>>>>>> 9c05b354549f97b5c29431dbae605d4664348fd0
 	{
-		std::vector<std::vector<Node<T>>> connectedComps;
+                SCCResult<T> result;
+                result.success = false;
 
 		if (!isDirectedGraph())
 		{
-			return connectedComps;//empty vector since for undirected graph strongly connected components do not exist
+                    result.errorMessage = ERR_UNDIR_GRAPH;
+                    return result;
 		}
 		else
 		{
@@ -2476,11 +2482,12 @@ namespace CXXGRAPH
 				if(visited[rem->getId()] == false){
 					std::vector<Node<T>> comp;
 					dfs_helper1(rem, comp);
-					connectedComps.push_back(comp);
+					result.stronglyConnectedComps.push_back(comp);
 				}
 			}
-
-			return connectedComps;
+                        
+                        result.success = true;
+			return result;
 		}
 	}
 

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -2316,7 +2316,6 @@ namespace CXXGRAPH
     }
 
 	template <typename T>
-        SCCResult<T> Graph<T>::kosaraju() const
 	TopoSortResult<T> Graph<T>::kahn() const
 	{
 		TopoSortResult<T> result;
@@ -2390,7 +2389,7 @@ namespace CXXGRAPH
 	}
 
 	template <typename T>
-	std::vector<std::vector<Node<T>>> Graph<T>::kosaraju() const
+        SCCResult<T> Graph<T>::kosaraju() const
 	{
                 SCCResult<T> result;
                 result.success = false;

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -2316,9 +2316,7 @@ namespace CXXGRAPH
     }
 
 	template <typename T>
-<<<<<<< HEAD
         SCCResult<T> Graph<T>::kosaraju() const
-=======
 	TopoSortResult<T> Graph<T>::kahn() const
 	{
 		TopoSortResult<T> result;
@@ -2393,7 +2391,6 @@ namespace CXXGRAPH
 
 	template <typename T>
 	std::vector<std::vector<Node<T>>> Graph<T>::kosaraju() const
->>>>>>> 9c05b354549f97b5c29431dbae605d4664348fd0
 	{
                 SCCResult<T> result;
                 result.success = false;

--- a/include/Utility/Typedef.hpp
+++ b/include/Utility/Typedef.hpp
@@ -101,7 +101,7 @@ namespace CXXGRAPH
     std::size_t operator () (const std::pair<T1,T2> &p) const {
         std::size_t h1 = std::hash<T1>{}(p.first);
         std::size_t h2 = std::hash<T2>{}(p.second);
-				return hash_combine(h1, h2);
+        return hash_combine(h1, h2);
     }
 	};
 
@@ -152,6 +152,21 @@ namespace CXXGRAPH
     };
     template <typename T>
     using TopoSortResult = TopoSortResult_struct<T>;
+    
+        // typedef for a collection of sets of vertices (useful for connected components algorithms) 
+        template <typename T>
+        using Components = std::vector<std::vector<Node<T>>>;
+
+    /// Struct that contains the information about strongly connected components (SCC) algorithms results
+        template<typename T>
+        struct SCCResult_struct
+        {
+            bool success = false;               // TRUE if the function does not return error, FALSE otherwise
+            std::string errorMessage = "";      // message of error
+            Components<T> stronglyConnectedComps;
+        };
+        template <typename T>
+        using SCCResult = SCCResult_struct<T>;
 
 	/// Struct that contains the information about Best First Search Algorithm results
 	template <typename T>

--- a/test/KosarajuTest.cpp
+++ b/test/KosarajuTest.cpp
@@ -1,0 +1,188 @@
+#include "gtest/gtest.h"
+#include <zlib.h>
+#include "CXXGraph.hpp"
+#include "Edge/DirectedEdge.hpp"
+#include "Edge/UndirectedEdge.hpp"
+#include "Graph/Graph.hpp"
+
+// helper function to compare strongly connected components (SCC) as computed
+// by the algorithm with expected (correct) SCC
+void compareComponents(CXXGRAPH::Components<int>& comp1, CXXGRAPH::Components<int>& comp2)
+{
+    ASSERT_EQ(comp1.size(), comp2.size());
+
+    for (size_t i = 0; i < comp1.size(); ++i) {
+        std::sort(comp1[i].begin(), comp1[i].end()); 
+        std::sort(comp2[i].begin(), comp2[i].end());
+    }
+
+    std::sort(comp1.begin(), comp1.end(),
+            [](auto& c1, auto& c2){ return c1.front() < c2.front(); } );
+
+    std::sort(comp2.begin(), comp2.end(),
+            [](auto& c1, auto& c2){ return c1.front() < c2.front(); } );
+
+    ASSERT_EQ(comp1, comp2);
+}
+
+// undirected graph
+TEST(KosarajuTest, test_1)
+{
+    CXXGRAPH::Node<int> node1("1", 1); 
+    CXXGRAPH::Node<int> node2("2", 2);
+    CXXGRAPH::UndirectedEdge<int> edge(1, node1, node2);
+    CXXGRAPH::T_EdgeSet<int> edgeSet;
+    edgeSet.insert(&edge);
+    CXXGRAPH::Graph<int> graph(edgeSet);
+    auto res = graph.kosaraju();
+    ASSERT_EQ(res.stronglyConnectedComps.size(), 0);
+    ASSERT_FALSE(res.success);
+    ASSERT_EQ(res.errorMessage, CXXGRAPH::ERR_UNDIR_GRAPH);
+}
+
+// 1 comp, 1 strongly connected comp
+TEST(KosarajuTest, test_2)
+{
+    CXXGRAPH::Node<int> node1("1", 1); 
+    CXXGRAPH::Node<int> node2("2", 2);
+    CXXGRAPH::DirectedEdge<int> edge1(1, node1, node2);
+    CXXGRAPH::DirectedEdge<int> edge2(2, node2, node1);
+    CXXGRAPH::T_EdgeSet<int> edgeSet; 
+    edgeSet.insert(&edge1);
+    edgeSet.insert(&edge2);
+    CXXGRAPH::Graph<int> graph(edgeSet);
+    auto res = graph.kosaraju();
+    ASSERT_TRUE(res.success);
+    ASSERT_EQ(res.errorMessage,"");
+    ASSERT_EQ(res.stronglyConnectedComps.size(), 1);
+    ASSERT_EQ(res.stronglyConnectedComps[0].size(), 2);
+}
+
+// 1 comp, 2 strongly connected comp
+TEST(KosarajuTest, test_3)
+{
+    CXXGRAPH::Node<int> node1("1", 1); 
+    CXXGRAPH::Node<int> node2("2", 2);
+    CXXGRAPH::Node<int> node3("3", 3);
+    CXXGRAPH::DirectedEdge<int> edge1(1, node1, node2);
+    CXXGRAPH::DirectedEdge<int> edge2(2, node2, node1);
+    CXXGRAPH::DirectedEdge<int> edge3(3, node3, node1);
+    CXXGRAPH::T_EdgeSet<int> edgeSet; 
+    edgeSet.insert(&edge1);
+    edgeSet.insert(&edge2);
+    edgeSet.insert(&edge3);
+    CXXGRAPH::Graph<int> graph(edgeSet);
+    auto res = graph.kosaraju();
+    ASSERT_TRUE(res.success);
+    ASSERT_EQ(res.errorMessage,"");
+
+    CXXGRAPH::Components<int> expectedComponents = {
+        {node1, node2},
+        {node3}
+    };
+    compareComponents(res.stronglyConnectedComps, expectedComponents);
+}
+
+// 2 components, 2 strongly connected comps 
+TEST(KosarajuTest, test_4)
+{
+    CXXGRAPH::Node<int> node1("1", 1); 
+    CXXGRAPH::Node<int> node2("2", 2);
+    CXXGRAPH::Node<int> node3("3", 3);
+    CXXGRAPH::Node<int> node4("4", 4);
+    CXXGRAPH::DirectedEdge<int> edge1(1, node1, node2);
+    CXXGRAPH::DirectedEdge<int> edge2(2, node2, node1);
+    CXXGRAPH::DirectedEdge<int> edge3(3, node3, node4);
+    CXXGRAPH::DirectedEdge<int> edge4(4, node4, node3);
+    CXXGRAPH::T_EdgeSet<int> edgeSet; 
+    edgeSet.insert(&edge1);
+    edgeSet.insert(&edge2);
+    edgeSet.insert(&edge3);
+    edgeSet.insert(&edge4);
+    CXXGRAPH::Graph<int> graph(edgeSet);
+    auto res = graph.kosaraju();
+    ASSERT_TRUE(res.success);
+    ASSERT_EQ(res.errorMessage,"");
+    CXXGRAPH::Components<int> expectedComponents = {
+        {node1, node2},
+        {node3, node4}
+    };
+    compareComponents(res.stronglyConnectedComps, expectedComponents);
+}
+
+TEST(KosarajuTest, test_5)
+{
+    CXXGRAPH::Node<int> node1("1", 1); 
+    CXXGRAPH::Node<int> node2("2", 2);
+    CXXGRAPH::Node<int> node3("3", 3);
+    CXXGRAPH::Node<int> node4("4", 4);
+    CXXGRAPH::Node<int> node5("5", 5);
+    CXXGRAPH::Node<int> node6("6", 6);
+    CXXGRAPH::Node<int> node7("7", 7);
+    CXXGRAPH::Node<int> node8("8", 8);
+    CXXGRAPH::Node<int> node9("9", 9);
+    CXXGRAPH::Node<int> node10("10", 10);
+    CXXGRAPH::Node<int> node11("11", 11);
+    CXXGRAPH::Node<int> node12("12", 12);
+    CXXGRAPH::Node<int> node13("13", 13);
+
+    CXXGRAPH::DirectedEdge<int> edge1(1, node1, node2);
+    CXXGRAPH::DirectedEdge<int> edge2(2, node1, node6);
+    CXXGRAPH::DirectedEdge<int> edge3(3, node3, node1);
+    CXXGRAPH::DirectedEdge<int> edge4(4, node3, node4);
+    CXXGRAPH::DirectedEdge<int> edge5(5, node4, node5);
+    CXXGRAPH::DirectedEdge<int> edge6(6, node4, node6);
+    CXXGRAPH::DirectedEdge<int> edge7(7, node6, node5);
+    CXXGRAPH::DirectedEdge<int> edge8(8, node5, node3);
+    CXXGRAPH::DirectedEdge<int> edge9(9, node7, node1);
+    CXXGRAPH::DirectedEdge<int> edge10(10, node7, node5);
+    CXXGRAPH::DirectedEdge<int> edge11(11, node7, node10);
+    CXXGRAPH::DirectedEdge<int> edge12(12, node12, node5);
+    CXXGRAPH::DirectedEdge<int> edge13(13, node8, node7);
+    CXXGRAPH::DirectedEdge<int> edge14(14, node8, node9);
+    CXXGRAPH::DirectedEdge<int> edge15(15, node9, node8);
+    CXXGRAPH::DirectedEdge<int> edge16(16, node9, node10);
+    CXXGRAPH::DirectedEdge<int> edge17(17, node10, node11);
+    CXXGRAPH::DirectedEdge<int> edge18(18, node10, node12);
+    CXXGRAPH::DirectedEdge<int> edge19(19, node12, node13);
+    CXXGRAPH::DirectedEdge<int> edge20(20, node11, node13);
+    CXXGRAPH::DirectedEdge<int> edge21(21, node13, node10);
+    
+    CXXGRAPH::T_EdgeSet<int> edgeSet;
+    edgeSet.insert(&edge1);
+    edgeSet.insert(&edge2);
+    edgeSet.insert(&edge3);
+    edgeSet.insert(&edge4);
+    edgeSet.insert(&edge5);
+    edgeSet.insert(&edge6);
+    edgeSet.insert(&edge7);
+    edgeSet.insert(&edge8);
+    edgeSet.insert(&edge9);
+    edgeSet.insert(&edge10);
+    edgeSet.insert(&edge11);
+    edgeSet.insert(&edge12);
+    edgeSet.insert(&edge13);
+    edgeSet.insert(&edge14);
+    edgeSet.insert(&edge15);
+    edgeSet.insert(&edge16);
+    edgeSet.insert(&edge17);
+    edgeSet.insert(&edge18);
+    edgeSet.insert(&edge19);
+    edgeSet.insert(&edge20);
+    edgeSet.insert(&edge21);
+
+    CXXGRAPH::Graph graph(edgeSet);
+    auto res = graph.kosaraju();
+    ASSERT_TRUE(res.success);
+    ASSERT_EQ(res.errorMessage,"");
+
+    CXXGRAPH::Components<int> expectedComponents = {
+        {node2},
+        {node1, node3, node4, node5, node6},
+        {node7},
+        {node8, node9},
+        {node10, node11, node12, node13}
+    };
+    
+    compareComponents(res.stronglyConnectedComps, expectedComponents);
+}


### PR DESCRIPTION
I implemented the changes discussed in #251 concerning the return type of Kosaraju's algorithm (I hope this correspond to what you had in mind) and written a few tests for it (#221).

For the return type, I introduced a SCCResult type (Strongly Connected Components Result), similar to what has been done for other algorithms in the library. Let me know if I can improve my PR in some way.