### PR TITLE
(Issue #277) Make CXXGraph MSVC-Compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,10 @@ if(DEBUG)
 		-O0  #no optimization
 		-g   #generate debug info
 	)
-
 endif(DEBUG)
 
 add_subdirectory(test)
-
 add_subdirectory(benchmark)
-
 add_subdirectory(examples)
 
 #install(FILES include/Graph.hpp DESTINATION /usr/include)

--- a/README.md
+++ b/README.md
@@ -93,10 +93,6 @@ If you are interested, please contact us at zigrazor@gmail.com or contribute to 
   - [How to use](#how-to-use)
   - [Example](#example)
   - [Unit-Test Execution](#unit-test-execution)
-    - [OpenSSL installation](#openssl-installation)
-      - [Ubuntu/Debian](#ubuntudebian)
-      - [RedHat/CentOS/RockyLinux/Fedora](#redhatcentosrockylinuxfedora)
-      - [Other System](#other-system)
     - [Google Test Installation](#google-test-installation)
     - [How to Compile Test](#how-to-compile-test)
     - [How to Run Test](#how-to-run-test)
@@ -192,8 +188,9 @@ The Classes Explanation can be found in the [Doxygen Documentation](https://rawc
 
 ## Requirements
 
-The minimun C++ standard required is **C++17** and a G++ compiler version greater than 7.3.0.
-Are also required [OpenSSL library](https://www.openssl.org/)
+- The minimum C++ standard required is **C++17**
+- A GCC compiler version greater than 7.3.0 *OR*
+- A MSVC compiler that supports C++17
 
 ## How to use
 
@@ -206,26 +203,6 @@ Work in Progess
 ## Unit-Test Execution
 
 The Unit-Test required the CMake version greater than 3.9 and the **google test**  library.
-
-### OpenSSL installation
-
-[OpenSSL](https://www.openssl.org/)
-
-#### Ubuntu/Debian
-
-``` bash
-sudo apt-get install openssl libssl-dev
-```
-
-#### RedHat/CentOS/RockyLinux/Fedora
-
-``` bash
-yum install openssl-devel
-```
-
-#### Other System
-
-You can find more information on how to install OpenSSL at this [link](https://github.com/openssl/openssl)
 
 ### Google Test Installation
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,7 +1,16 @@
 option(BENCHMARK "Enable Benchmark" OFF)
+option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
+
 if(BENCHMARK)
 
 	include(FetchContent)
+
+	FetchContent_Declare(
+		googletest
+		GIT_REPOSITORY https://github.com/google/googletest.git
+		GIT_TAG origin/main
+		#GIT_TAG        v1.13.0 # release-1.13.0
+    )
 
 	FetchContent_Declare(
     	googlebenchmark
@@ -10,21 +19,20 @@ if(BENCHMARK)
 	)
 
 	FetchContent_Declare(
-    openssl
-    GIT_REPOSITORY https://github.com/janbar/openssl-cmake.git
-    GIT_TAG origin/master
-    OPTIONS "WITH_APPS OFF"
+		openssl
+		GIT_REPOSITORY https://github.com/janbar/openssl-cmake.git
+		GIT_TAG origin/master
     )
 
     FetchContent_Declare(
-    zlib
-    GIT_REPOSITORY https://github.com/madler/zlib.git
-    GIT_TAG v1.2.13
-    OPTIONS "CMAKE_POSITION_INDEPENDENT_CODE True"
+		zlib
+		GIT_REPOSITORY https://github.com/madler/zlib.git
+		GIT_TAG v1.2.13
     )
 
 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
+	FetchContent_MakeAvailable(googletest)
+    FetchContent_MakeAvailable(googlebenchmark)
 
     set(WITH_APPS OFF CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(openssl)
@@ -41,14 +49,14 @@ if(BENCHMARK)
 		PUBLIC WITH_COMPRESSION
 	)
 	target_include_directories(benchmark_exe PUBLIC
-		PUBLIC "${PROJECT_SOURCE_DIR}/include"
+		PUBLIC ${PROJECT_SOURCE_DIR}/include
 		PUBLIC ${zlib_BINARY_DIR}
 		PUBLIC ${zlib_SOURCE_DIR}
 		PUBLIC ${openssl_SOURCE_DIR}/include
 	)
 	target_link_libraries(benchmark_exe
+		PUBLIC GTest::gtest
 		PUBLIC benchmark::benchmark
-		PUBLIC pthread
 		PUBLIC ssl
 		PUBLIC crypto
 		PUBLIC zlibstatic)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -10,37 +10,37 @@ if(BENCHMARK)
 		GIT_REPOSITORY https://github.com/google/googletest.git
 		GIT_TAG origin/main
 		#GIT_TAG        v1.13.0 # release-1.13.0
-    )
+	)
 
 	FetchContent_Declare(
-    	googlebenchmark
-    	GIT_REPOSITORY https://github.com/google/benchmark.git
-    	GIT_TAG origin/main
+		googlebenchmark
+		GIT_REPOSITORY https://github.com/google/benchmark.git
+		GIT_TAG origin/main
 	)
 
 	FetchContent_Declare(
 		openssl
 		GIT_REPOSITORY https://github.com/janbar/openssl-cmake.git
 		GIT_TAG origin/master
-    )
+	)
 
-    FetchContent_Declare(
+	FetchContent_Declare(
 		zlib
 		GIT_REPOSITORY https://github.com/madler/zlib.git
 		GIT_TAG v1.2.13
-    )
+	)
 
 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 	FetchContent_MakeAvailable(googletest)
-    FetchContent_MakeAvailable(googlebenchmark)
+	FetchContent_MakeAvailable(googlebenchmark)
 
-    set(WITH_APPS OFF CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(openssl)
+	set(WITH_APPS OFF CACHE BOOL "" FORCE)
+	FetchContent_MakeAvailable(openssl)
 
-    set(SAVE_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
-    set(CMAKE_POSITION_INDEPENDENT_CODE True)
-    FetchContent_MakeAvailable(zlib)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ${SAVE_CMAKE_POSITION_INDEPENDENT_CODE})
+	set(SAVE_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
+	set(CMAKE_POSITION_INDEPENDENT_CODE True)
+	FetchContent_MakeAvailable(zlib)
+	set(CMAKE_POSITION_INDEPENDENT_CODE ${SAVE_CMAKE_POSITION_INDEPENDENT_CODE})
 
 	file (GLOB BENCHMARK_FILES "*.cpp" "*.hpp")
 	add_executable(benchmark_exe ${BENCHMARK_FILES})
@@ -59,5 +59,6 @@ if(BENCHMARK)
 		PUBLIC benchmark::benchmark
 		PUBLIC ssl
 		PUBLIC crypto
-		PUBLIC zlibstatic)
+		PUBLIC zlibstatic
+	)
 endif(BENCHMARK)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -19,12 +19,6 @@ if(BENCHMARK)
 	)
 
 	FetchContent_Declare(
-		openssl
-		GIT_REPOSITORY https://github.com/janbar/openssl-cmake.git
-		GIT_TAG origin/master
-	)
-
-	FetchContent_Declare(
 		zlib
 		GIT_REPOSITORY https://github.com/madler/zlib.git
 		GIT_TAG v1.2.13
@@ -33,9 +27,6 @@ if(BENCHMARK)
 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 	FetchContent_MakeAvailable(googletest)
 	FetchContent_MakeAvailable(googlebenchmark)
-
-	set(WITH_APPS OFF CACHE BOOL "" FORCE)
-	FetchContent_MakeAvailable(openssl)
 
 	set(SAVE_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
 	set(CMAKE_POSITION_INDEPENDENT_CODE True)
@@ -52,13 +43,10 @@ if(BENCHMARK)
 		PUBLIC ${PROJECT_SOURCE_DIR}/include
 		PUBLIC ${zlib_BINARY_DIR}
 		PUBLIC ${zlib_SOURCE_DIR}
-		PUBLIC ${openssl_SOURCE_DIR}/include
 	)
 	target_link_libraries(benchmark_exe
 		PUBLIC GTest::gtest
 		PUBLIC benchmark::benchmark
-		PUBLIC ssl
-		PUBLIC crypto
 		PUBLIC zlibstatic
 	)
 endif(BENCHMARK)

--- a/benchmark/Graph_BM.cpp
+++ b/benchmark/Graph_BM.cpp
@@ -1,5 +1,4 @@
 #include <benchmark/benchmark.h>
-#include <unistd.h>
 
 #include "CXXGraph.hpp"
 #include "Utilities.hpp"

--- a/benchmark/Node_BM.cpp
+++ b/benchmark/Node_BM.cpp
@@ -1,5 +1,4 @@
 #include <benchmark/benchmark.h>
-#include <openssl/sha.h>
 
 #include "CXXGraph.hpp"
 #include "Utilities.hpp"

--- a/benchmark/Utilities.hpp
+++ b/benchmark/Utilities.hpp
@@ -1,6 +1,7 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
 #include <time.h>
+
 #include <random>
 
 #include "CXXGraph.hpp"
@@ -11,7 +12,7 @@ static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(
   thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
 
   std::map<unsigned long, CXXGRAPH::Node<int> *> nodes;
-  
+
   unsigned int randSeed = (unsigned int)time(NULL);
   rand.seed(randSeed);
   int randomNumber;

--- a/benchmark/Utilities.hpp
+++ b/benchmark/Utilities.hpp
@@ -1,18 +1,22 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
-#include <stdlib.h>
 #include <time.h>
+#include <random>
 
 #include "CXXGraph.hpp"
 
 static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(
     unsigned long numberOfNodes, int MaxValue) {
+  thread_local static std::default_random_engine rand;
+  thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
+
   std::map<unsigned long, CXXGRAPH::Node<int> *> nodes;
+  
   unsigned int randSeed = (unsigned int)time(NULL);
-  srand(randSeed);
+  rand.seed(randSeed);
   int randomNumber;
   for (auto index = 0; index < numberOfNodes; index++) {
-    randomNumber = (rand_r(&randSeed) % MaxValue) + 1;
+    randomNumber = (distribution(rand) % MaxValue) + 1;
     CXXGRAPH::Node<int> *newNode =
         new CXXGRAPH::Node<int>(std::to_string(index), randomNumber);
     nodes[index] = newNode;
@@ -23,15 +27,19 @@ static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(
 static std::map<unsigned long, CXXGRAPH::Edge<int> *> generateRandomEdges(
     unsigned long numberOfEdges,
     std::map<unsigned long, CXXGRAPH::Node<int> *> nodes) {
+  thread_local static std::default_random_engine rand;
+  thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
+
   std::map<unsigned long, CXXGRAPH::Edge<int> *> edges;
+
   unsigned int randSeed = (unsigned int)time(NULL);
-  srand(randSeed);
+  rand.seed(randSeed);
   int randomNumber1;
   int randomNumber2;
   auto MaxValue = nodes.size();
   for (auto index = 0; index < numberOfEdges; index++) {
-    randomNumber1 = (rand_r(&randSeed) % MaxValue);
-    randomNumber2 = (rand_r(&randSeed) % MaxValue);
+    randomNumber1 = (distribution(rand) % MaxValue);
+    randomNumber2 = (distribution(rand) % MaxValue);
     CXXGRAPH::Edge<int> *newEdge = new CXXGRAPH::Edge<int>(
         index, *(nodes.at(randomNumber1)), *(nodes.at(randomNumber2)));
     edges[index] = newEdge;
@@ -43,15 +51,20 @@ static std::map<unsigned long, CXXGRAPH::UndirectedEdge<int> *>
 generateRandomUndirectedEdges(
     unsigned long numberOfEdges,
     std::map<unsigned long, CXXGRAPH::Node<int> *> nodes) {
+  thread_local static std::default_random_engine rand;
+  thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
+
   std::map<unsigned long, CXXGRAPH::UndirectedEdge<int> *> edges;
+
   unsigned int randSeed = (unsigned int)time(NULL);
-  srand(randSeed);
+  rand.seed(randSeed);
+
   int randomNumber1;
   int randomNumber2;
   auto MaxValue = nodes.size();
   for (auto index = 0; index < numberOfEdges; index++) {
-    randomNumber1 = (rand_r(&randSeed) % MaxValue);
-    randomNumber2 = (rand_r(&randSeed) % MaxValue);
+    randomNumber1 = (distribution(rand) % MaxValue);
+    randomNumber2 = (distribution(rand) % MaxValue);
     CXXGRAPH::UndirectedEdge<int> *newEdge = new CXXGRAPH::UndirectedEdge<int>(
         index, *(nodes.at(randomNumber1)), *(nodes.at(randomNumber2)));
     edges[index] = newEdge;

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -2288,12 +2288,12 @@ const DialResult Graph<T>::dial(const Node<T> &source, int maxWeight) const {
             i.second->isDirected().value()) {
           const DirectedWeightedEdge<T> *dw_edge =
               dynamic_cast<const DirectedWeightedEdge<T> *>(i.second);
-          weight = dw_edge->getWeight();
+          weight = (int)dw_edge->getWeight();
         } else if (i.second->isDirected().has_value() &&
                    !i.second->isDirected().value()) {
           const UndirectedWeightedEdge<T> *udw_edge =
               dynamic_cast<const UndirectedWeightedEdge<T> *>(i.second);
-          weight = udw_edge->getWeight();
+          weight = (int)udw_edge->getWeight();
         } else {
           // ERROR it shouldn't never returned ( does not exist a Node Weighted
           // and not Directed/Undirected)

--- a/include/Node/Node.hpp
+++ b/include/Node/Node.hpp
@@ -21,7 +21,6 @@
 #define __CXXGRAPH_NODE_H__
 
 #pragma once
-#include <openssl/sha.h>
 
 #include <iomanip>
 #include <iostream>

--- a/include/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/Partitioning/CoordinatedPartitionState.hpp
@@ -110,19 +110,19 @@ std::shared_ptr<Record<T>> CoordinatedPartitionState<T>::getRecord(
 template <typename T>
 int CoordinatedPartitionState<T>::getMachineLoad(const int m) const {
   std::lock_guard<std::mutex> lock(*machines_load_edges_mutex);
-  return machines_load_edges.at(m);
+  return (int)machines_load_edges.at(m);
 }
 
 template <typename T>
 int CoordinatedPartitionState<T>::getMachineWeight(const int m) const {
   std::lock_guard<std::mutex> lock(*machines_weight_edges_mutex);
-  return machines_weight_edges.at(m);
+  return (int)machines_weight_edges.at(m);
 }
 
 template <typename T>
 int CoordinatedPartitionState<T>::getMachineLoadVertices(const int m) const {
   std::lock_guard<std::mutex> lock(*machines_load_vertices_mutex);
-  return machines_load_vertices.at(m);
+  return (int)machines_load_vertices.at(m);
 }
 template <typename T>
 void CoordinatedPartitionState<T>::incrementMachineLoad(const int m,

--- a/include/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/Partitioning/CoordinatedPartitionState.hpp
@@ -73,6 +73,7 @@ class CoordinatedPartitionState : public PartitionState<T> {
   std::vector<int> getMachines_loadVertices() const;
   const PartitionMap<T> &getPartitionMap() const;
 };
+
 template <typename T>
 CoordinatedPartitionState<T>::CoordinatedPartitionState(const Globals &G)
     : record_map(),
@@ -92,8 +93,10 @@ CoordinatedPartitionState<T>::CoordinatedPartitionState(const Globals &G)
   }
   MAX_LOAD = 0;
 }
+
 template <typename T>
 CoordinatedPartitionState<T>::~CoordinatedPartitionState() {}
+
 template <typename T>
 std::shared_ptr<Record<T>> CoordinatedPartitionState<T>::getRecord(
     const int x) {

--- a/include/Partitioning/GreedyVertexCut.hpp
+++ b/include/Partitioning/GreedyVertexCut.hpp
@@ -49,10 +49,10 @@ class GreedyVertexCut : public PartitionStrategy<T> {
 };
 
 template <typename T>
-GreedyVertexCut<T>::GreedyVertexCut(const Globals &G) : GLOBALS(G) { }
+GreedyVertexCut<T>::GreedyVertexCut(const Globals &G) : GLOBALS(G) {}
 
 template <typename T>
-GreedyVertexCut<T>::~GreedyVertexCut() { }
+GreedyVertexCut<T>::~GreedyVertexCut() {}
 
 template <typename T>
 void GreedyVertexCut<T>::performStep(const Edge<T> &e,
@@ -179,7 +179,7 @@ void GreedyVertexCut<T>::performStep(const Edge<T> &e,
   // Use TLS statics to pay init cost once per-thread
   thread_local static std::default_random_engine rand;
   thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
-  
+
   unsigned int seed = (unsigned int)time(NULL);
   rand.seed(seed);
 

--- a/include/Partitioning/GreedyVertexCut.hpp
+++ b/include/Partitioning/GreedyVertexCut.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <chrono>
+#include <random>
 
 #include "Edge/Edge.hpp"
 #include "PartitionStrategy.hpp"
@@ -46,12 +47,13 @@ class GreedyVertexCut : public PartitionStrategy<T> {
 
   void performStep(const Edge<T> &e, PartitionState<T> &Sstate) override;
 };
+
 template <typename T>
-GreedyVertexCut<T>::GreedyVertexCut(const Globals &G) : GLOBALS(G) {
-  // this->GLOBALS = G;
-}
+GreedyVertexCut<T>::GreedyVertexCut(const Globals &G) : GLOBALS(G) { }
+
 template <typename T>
-GreedyVertexCut<T>::~GreedyVertexCut() {}
+GreedyVertexCut<T>::~GreedyVertexCut() { }
+
 template <typename T>
 void GreedyVertexCut<T>::performStep(const Edge<T> &e,
                                      PartitionState<T> &state) {
@@ -66,7 +68,6 @@ void GreedyVertexCut<T>::performStep(const Edge<T> &e,
   //*** ASK FOR LOCK
   bool locks_taken = false;
   while (!locks_taken) {
-    srand((unsigned)time(NULL));
     int usleep_time = 2;
     while (!u_record->getLock()) {
       std::this_thread::sleep_for(std::chrono::microseconds(usleep_time));
@@ -175,10 +176,14 @@ void GreedyVertexCut<T>::performStep(const Edge<T> &e,
   }
 
   //*** PICK A RANDOM ELEMENT FROM CANDIDATES
-  /* initialize random seed: */
+  // Use TLS statics to pay init cost once per-thread
+  thread_local static std::default_random_engine rand;
+  thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
+  
   unsigned int seed = (unsigned int)time(NULL);
-  srand(seed);
-  int choice = rand_r(&seed) % candidates.size();
+  rand.seed(seed);
+
+  int choice = distribution(rand) % candidates.size();
   machine_id = candidates.at(choice);
   try {
     CoordinatedPartitionState<T> &cord_state =

--- a/include/Partitioning/HDRF.hpp
+++ b/include/Partitioning/HDRF.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <chrono>
+#include <random>
 
 #include "Edge/Edge.hpp"
 #include "PartitionStrategy.hpp"
@@ -148,10 +149,13 @@ void HDRF<T>::performStep(const Edge<T> &e, PartitionState<T> &state) {
   }
 
   //*** PICK A RANDOM ELEMENT FROM CANDIDATES
-  /* initialize random seed: */
+  thread_local static std::default_random_engine rand;
+  thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
+  
   unsigned int seed = (unsigned int)time(NULL);
-  srand(seed);
-  int choice = rand_r(&seed) % candidates.size();
+  rand.seed(seed);
+
+  int choice = distribution(rand) % candidates.size();
   machine_id = candidates.at(choice);
   try {
     CoordinatedPartitionState<T> &cord_state =

--- a/include/Partitioning/HDRF.hpp
+++ b/include/Partitioning/HDRF.hpp
@@ -151,7 +151,7 @@ void HDRF<T>::performStep(const Edge<T> &e, PartitionState<T> &state) {
   //*** PICK A RANDOM ELEMENT FROM CANDIDATES
   thread_local static std::default_random_engine rand;
   thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
-  
+
   unsigned int seed = (unsigned int)time(NULL);
   rand.seed(seed);
 

--- a/include/Partitioning/Partitioner.hpp
+++ b/include/Partitioning/Partitioner.hpp
@@ -158,8 +158,8 @@ CoordinatedPartitionState<T> Partitioner<T>::startCoordinated() {
       list_vector[t] =
           std::vector<const Edge<T> *>(std::next(dataset->begin(), iStart),
                                        std::next(dataset->begin(), iEnd));
-      myRunnable[t].reset(new PartitionerThread<T>(list_vector[t],
-                                                             &state, algorithm));
+      myRunnable[t].reset(
+          new PartitionerThread<T>(list_vector[t], &state, algorithm));
       myThreads[t] = std::thread(&Runnable::run, myRunnable[t].get());
     }
   }

--- a/test/BFSTest.cpp
+++ b/test/BFSTest.cpp
@@ -1,5 +1,5 @@
-#include <vector>
 #include <random>
+#include <vector>
 
 #include "CXXGraph.hpp"
 #include "gtest/gtest.h"
@@ -281,7 +281,7 @@ TEST(BFSTest, test_12) {
 TEST(BFSTest, test_13) {
   thread_local static std::default_random_engine rand;
   thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
-  
+
   unsigned int randSeed = (unsigned int)time(NULL);
   rand.seed(randSeed);
 

--- a/test/BFSTest.cpp
+++ b/test/BFSTest.cpp
@@ -1,4 +1,5 @@
 #include <vector>
+#include <random>
 
 #include "CXXGraph.hpp"
 #include "gtest/gtest.h"
@@ -278,13 +279,16 @@ TEST(BFSTest, test_12) {
 
 // this case is to verify result correction when number of threads more than 1
 TEST(BFSTest, test_13) {
+  thread_local static std::default_random_engine rand;
+  thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
+  
   unsigned int randSeed = (unsigned int)time(NULL);
-  srand(randSeed);
+  rand.seed(randSeed);
 
   int nodes_size = 60, edges_size = 2000;
   std::vector<CXXGRAPH::Node<int> *> nodes;
   for (auto index = 0; index < nodes_size; index++) {
-    int randomNumber = (rand_r(&randSeed) % nodes_size) + 1;
+    int randomNumber = (distribution(rand) % nodes_size) + 1;
     CXXGRAPH::Node<int> *newNode =
         new CXXGRAPH::Node<int>(std::to_string(index), randomNumber);
     nodes.push_back(newNode);
@@ -293,8 +297,8 @@ TEST(BFSTest, test_13) {
   CXXGRAPH::T_EdgeSet<int> edgeSet;
   auto MaxValue = nodes.size();
   for (auto index = 0; index < edges_size; index++) {
-    int randomNumber1 = (rand_r(&randSeed) % MaxValue);
-    int randomNumber2 = (rand_r(&randSeed) % MaxValue);
+    int randomNumber1 = (distribution(rand) % MaxValue);
+    int randomNumber2 = (distribution(rand) % MaxValue);
     if (randomNumber1 != randomNumber2) {
       CXXGRAPH::UndirectedEdge<int> *newEdge =
           new CXXGRAPH::UndirectedEdge<int>(index, *(nodes.at(randomNumber1)),

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,12 +32,6 @@ if(TEST)
     )
 
     FetchContent_Declare(
-        openssl
-        GIT_REPOSITORY https://github.com/janbar/openssl-cmake.git
-        GIT_TAG origin/master
-    )
-
-    FetchContent_Declare(
         zlib
         GIT_REPOSITORY https://github.com/madler/zlib.git
         GIT_TAG v1.2.13
@@ -45,9 +39,6 @@ if(TEST)
 
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
-
-    set(WITH_APPS OFF CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(openssl)
 
     set(SAVE_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
     set(CMAKE_POSITION_INDEPENDENT_CODE True)
@@ -65,13 +56,11 @@ if(TEST)
         PUBLIC "${PROJECT_SOURCE_DIR}/include"
         PUBLIC ${zlib_BINARY_DIR}
         PUBLIC ${zlib_SOURCE_DIR}
-        PUBLIC ${openssl_SOURCE_DIR}/include
     )
     target_link_libraries(test_exe
         PUBLIC GTest::gtest_main
-        PUBLIC ssl
-        PUBLIC crypto
-        PUBLIC zlibstatic)
+        PUBLIC zlibstatic
+    )
 
     enable_testing()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,23 +23,24 @@ endif(CODE_COVERAGE)
 option(TEST "Enable Test" OFF)
 if(TEST)
     include(FetchContent)
+
     FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG origin/main
-    #GIT_TAG        v1.13.0 # release-1.13.0
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG origin/main
+        #GIT_TAG        v1.13.0 # release-1.13.0
     )
 
     FetchContent_Declare(
-    openssl
-    GIT_REPOSITORY https://github.com/janbar/openssl-cmake.git
-    GIT_TAG origin/master
+        openssl
+        GIT_REPOSITORY https://github.com/janbar/openssl-cmake.git
+        GIT_TAG origin/master
     )
 
     FetchContent_Declare(
-    zlib
-    GIT_REPOSITORY https://github.com/madler/zlib.git
-    GIT_TAG v1.2.13
+        zlib
+        GIT_REPOSITORY https://github.com/madler/zlib.git
+        GIT_TAG v1.2.13
     )
 
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,7 @@
 option(CODE_COVERAGE "Enable coverage reporting" OFF)
+option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
+option(gtest_disable_pthreads "Disable uses of pthreads in gtest." ON)
+
 if(CODE_COVERAGE)
 	message( "Code Coverage Enabled" )
 	add_compile_options(
@@ -65,7 +68,6 @@ if(TEST)
     )
     target_link_libraries(test_exe
         PUBLIC GTest::gtest_main
-        PUBLIC pthread
         PUBLIC ssl
         PUBLIC crypto
         PUBLIC zlibstatic)

--- a/test/NodeTest.cpp
+++ b/test/NodeTest.cpp
@@ -26,7 +26,7 @@ std::ostream &operator<<(std::ostream &os, const testStruct &TestStruct) {
 TEST(StringNodeTest, StringConstructor) {
   // Testing constructor and getters with different types of data
   int intTest = 42;
-  float floatTest = 3.14;
+  float floatTest = 3.14f;
   double doubleTest = 3.1416;
   bool boolTest = true;
   char charTest = 'w';

--- a/test/NodeTest.cpp
+++ b/test/NodeTest.cpp
@@ -91,6 +91,8 @@ TEST(StringNodeTest, StringeqOperator) {
   ASSERT_FALSE(nodeStruct1 == nodeStruct2);  // completely different
 }
 
+#include <iostream>
+
 TEST(StringNodeTest, StringltOperator) {
   // Testing Less Than operator with different types of data
   int int1 = 2;
@@ -113,9 +115,6 @@ TEST(StringNodeTest, StringltOperator) {
 
   ASSERT_FALSE(nodeInt1 < nodeInt2);        // Same id same data
   ASSERT_FALSE(nodeDouble1 < nodeDouble2);  // Same id different data
-  // hash of 1 is greater than 2
-  ASSERT_TRUE(nodeString2 < nodeString1);   // Different id different id
-  ASSERT_FALSE(nodeStruct2 < nodeStruct1);  // completely different
 }
 
 TEST(StringNodeTest, StringprintOperator) {

--- a/test/Utilities.hpp
+++ b/test/Utilities.hpp
@@ -1,17 +1,22 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
-#include <stdlib.h>
 #include <time.h>
+#include <random>
 
 #include "CXXGraph.hpp"
 
 static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(
     unsigned long numberOfNodes, int MaxValue) {
+  thread_local static std::default_random_engine rand;
+  thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
+
   std::map<unsigned long, CXXGRAPH::Node<int> *> nodes;
+  
   unsigned int randSeed = (unsigned int)time(NULL);
-  srand(randSeed);
+  rand.seed(randSeed);
+  
   for (auto index = 0; index < numberOfNodes; index++) {
-    int randomNumber = (rand_r(&randSeed) % MaxValue) + 1;
+    int randomNumber = (distribution(rand) % MaxValue) + 1;
     CXXGRAPH::Node<int> *newNode =
         new CXXGRAPH::Node<int>(std::to_string(index), randomNumber);
     nodes[index] = newNode;
@@ -22,13 +27,18 @@ static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(
 static std::map<unsigned long, CXXGRAPH::Edge<int> *> generateRandomEdges(
     unsigned long numberOfEdges,
     std::map<unsigned long, CXXGRAPH::Node<int> *> nodes) {
+  thread_local static std::default_random_engine rand;
+  thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
+
   std::map<unsigned long, CXXGRAPH::Edge<int> *> edges;
+
   unsigned int randSeed = (unsigned int)time(NULL);
-  srand(randSeed);
+  rand.seed(randSeed);
+
   auto MaxValue = nodes.size();
   for (auto index = 0; index < numberOfEdges; index++) {
-    int randomNumber1 = (rand_r(&randSeed) % MaxValue);
-    int randomNumber2 = (rand_r(&randSeed) % MaxValue);
+    int randomNumber1 = (distribution(rand) % MaxValue);
+    int randomNumber2 = (distribution(rand) % MaxValue);
     CXXGRAPH::Edge<int> *newEdge = new CXXGRAPH::Edge<int>(
         index, *(nodes.at(randomNumber1)), *(nodes.at(randomNumber2)));
     edges[index] = newEdge;

--- a/test/Utilities.hpp
+++ b/test/Utilities.hpp
@@ -1,6 +1,7 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
 #include <time.h>
+
 #include <random>
 
 #include "CXXGraph.hpp"
@@ -11,10 +12,10 @@ static std::map<unsigned long, CXXGRAPH::Node<int> *> generateRandomNodes(
   thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);
 
   std::map<unsigned long, CXXGRAPH::Node<int> *> nodes;
-  
+
   unsigned int randSeed = (unsigned int)time(NULL);
   rand.seed(randSeed);
-  
+
   for (auto index = 0; index < numberOfNodes; index++) {
     int randomNumber = (distribution(rand) % MaxValue) + 1;
     CXXGRAPH::Node<int> *newNode =


### PR DESCRIPTION
In this PR, we're switching out calls to `srand` and `rand_r` (in which `rand_r` is a Unix-only function included in `<stdlib.h>`), with usages of `std::random` constructs.

These constructs are initialized in a thread-safe manner using TLS:
```
  thread_local static std::default_random_engine rand;
  thread_local static std::uniform_int_distribution distribution(0, RAND_MAX);

  rand.seed(some_seed);
  distribution(rand); // Computes the next random number in the sequence.
```

The reason we use TLS is to pay the initialization cost only once per-thread. This ensures thread-safety of the PRNG sequence, as well as providing a decent tradeoff between performance and memory.

- A reference to a related issue in your repository.
  - https://github.com/ZigRazor/CXXGraph/issues/277
- A description of the changes proposed in the pull request.
  - Switch usages of `srand` and `rand_r` to the more cross-platform `<random>` implementations.
  - Remove 2 test asserts that relied on comparisons of platform-dependent hashing implementations.
- @mentions of the person or team responsible for reviewing proposed changes. ( optional ) 
  - @ZigRazor 