### PR TITLE
Remove static_cast of 0 to template type T in best_first_search

### DIFF
--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -1631,7 +1631,7 @@ BestFirstSearchResult<T> Graph<T>::best_first_search(
 
   std::vector<Node<T>> visited;
   visited.push_back(source);
-  pq.push(std::make_pair(static_cast<T>(0), &source));
+  pq.push(std::make_pair(0.0, &source));
 
   while (!pq.empty()) {
     const Node<T> *currentNode = pq.top().second;


### PR DESCRIPTION
Small fix in Graph::best_first_search function due to a cast that prevented the use of non native types as data types for the nodes (referenced in issue #284)
