### PR TITLE
introduce tarjan's algorithm (#103)

### DIFF
--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -20,6 +20,7 @@
 #ifndef __CXXGRAPH_GRAPH_H__
 #define __CXXGRAPH_GRAPH_H__
 
+#include <cstdio>
 #pragma once
 
 #include <limits.h>
@@ -2678,7 +2679,7 @@ const TarjanResult<T> Graph<T>::tarjan(const unsigned int typeMask) const {
   std::unordered_map<size_t, int>
       discoveryTime;  // the timestamp when a node is visited
   std::unordered_map<size_t, int>
-      lowestDisc;  // the lowest discory time of all
+      lowestDisc;  // the lowest discovery time of all
                    // reachable nodes from current node
   int timestamp = 0;
   size_t rootId = 0;
@@ -2791,6 +2792,9 @@ const TarjanResult<T> Graph<T>::tarjan(const unsigned int typeMask) const {
               // the current node has been poped out
               Node<T> nodeAtTop = nodeStack.top();
               nodeStack.pop();
+              if (typeMask & TARJAN_FIND_SCC) {
+                inStack.erase(nodeAtTop.getId());
+              }
               connectedComp.emplace_back(nodeAtTop);
               if (nodeAtTop == *curNode) {
                 break;
@@ -2813,6 +2817,7 @@ const TarjanResult<T> Graph<T>::tarjan(const unsigned int typeMask) const {
     }
   }
 
+  result.success = true;
   return result;
 }
 

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -2757,7 +2757,7 @@ const TarjanResult<T> Graph<T>::tarjan(const unsigned int typeMask) const {
                   while (true) {
                     // pop a top node out of stack until
                     // the neighbor node has been poped out
-                    Node<T> nodeAtTop = sccNodeStack.top();
+                    Node<T> nodeAtTop = vbccNodeStack.top();
                     vbccNodeStack.pop();
                     vbcc.emplace_back(nodeAtTop);
                     if (nodeAtTop == *neighborNode) {

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -359,6 +359,21 @@ class Graph {
   virtual const DijkstraResult dijkstra(const Node<T> &source,
                                         const Node<T> &target) const;
   /**
+   * @brief This function runs the tarjan algorithm and returns different types
+   * of results depending on the input parameter typeMask.
+   *
+   * @param typeMask each bit of typeMask within valid range represents a kind
+   * of results should be returned.
+   *
+   * Note: No Thread Safe
+   *
+   * @return The types of return include strongly connected components
+   * (only for directed graphs) and cut vertices、 bridges、edge
+   * biconnected components and vertice biconnected components
+   * (only for undirected graphs).
+   */
+  virtual const TarjanResult<T> tarjan(const unsigned int typeMask) const;
+  /**
    * @brief Function runs the bellman-ford algorithm for some source node and
    * target node in the graph and returns the shortest distance of target
    * from the source. It can also detect if a negative cycle exists in the
@@ -2540,7 +2555,7 @@ bool Graph<T>::isUndirectedGraph() const {
 }
 
 template <typename T>
-void Graph<T>::reverseDirectedGraph(){
+void Graph<T>::reverseDirectedGraph() {
   if (!isDirectedGraph()) {
     throw std::runtime_error(ERR_UNDIR_GRAPH);
   }
@@ -2634,6 +2649,171 @@ bool Graph<T>::isStronglyConnectedGraph() const {
     }
     return true;
   }
+}
+
+template <typename T>
+const TarjanResult<T> Graph<T>::tarjan(const unsigned int typeMask) const {
+  TarjanResult<T> result;
+  result.success = false;
+  bool isDirected = this->isDirectedGraph();
+  if (isDirected) {
+    // check whether targetMask is a subset of the mask for directed graph
+    unsigned int directedMask = TARJAN_FIND_SCC;
+    if ((typeMask | directedMask) != directedMask) {
+      result.errorMessage = ERR_DIR_GRAPH;
+      return result;
+    }
+  } else {
+    // check whether targetMask is a subset of the mask for undirected graph
+    unsigned int undirectedMask = (TARJAN_FIND_CUTV | TARJAN_FIND_BRIDGE |
+                                   TARJAN_FIND_VBCC | TARJAN_FIND_EBCC);
+    if ((typeMask | undirectedMask) != undirectedMask) {
+      result.errorMessage = ERR_UNDIR_GRAPH;
+      return result;
+    }
+  }
+
+  const auto &adjMatrix = getAdjMatrix();
+  const auto &nodeSet = getNodeSet();
+  std::unordered_map<size_t, int>
+      discoveryTime;  // the timestamp when a node is visited
+  std::unordered_map<size_t, int>
+      lowestDisc;  // the lowest discory time of all
+                   // reachable nodes from current node
+  int timestamp = 0;
+  size_t rootId = 0;
+  std::stack<Node<T>> sccNodeStack;
+  std::stack<Node<T>> ebccNodeStack;
+  std::stack<Node<T>> vbccNodeStack;
+  std::unordered_set<size_t> inStack;
+  std::function<void(const shared<const Node<T>>, const shared<const Edge<T>>)>
+      dfs_helper = [this, typeMask, isDirected, &dfs_helper, &adjMatrix,
+                    &discoveryTime, &lowestDisc, &timestamp, &rootId,
+                    &sccNodeStack, &ebccNodeStack, &vbccNodeStack, &inStack,
+                    &result](const shared<const Node<T>> curNode,
+                             const shared<const Edge<T>> prevEdge) {
+        // record the visited time of current node
+        discoveryTime[curNode->getId()] = timestamp;
+        lowestDisc[curNode->getId()] = timestamp;
+        timestamp++;
+        if (typeMask & TARJAN_FIND_SCC) {
+          sccNodeStack.emplace(*curNode);
+          inStack.emplace(curNode->getId());
+        }
+        if (typeMask & TARJAN_FIND_EBCC) {
+          ebccNodeStack.emplace(*curNode);
+        }
+        if (typeMask & TARJAN_FIND_VBCC) {
+          vbccNodeStack.emplace(*curNode);
+        }
+        // travel the neighbors
+        int numSon = 0;
+        bool nodeIsAdded =
+            false;  // whether a node has been marked as a cut vertice
+        if (adjMatrix->find(curNode) != adjMatrix->end()) {
+          for (const auto &[neighborNode, edge] : adjMatrix->at(curNode)) {
+            if (!discoveryTime.count(neighborNode->getId())) {
+              dfs_helper(neighborNode, edge);
+              lowestDisc[curNode->getId()] =
+                  std::min(lowestDisc[curNode->getId()],
+                           lowestDisc[neighborNode->getId()]);
+
+              if (typeMask & TARJAN_FIND_BRIDGE) {
+                // lowestDisc of neighbor node is larger than that of current
+                // node means we can travel back to a visited node only through
+                // this edge
+                if (discoveryTime[curNode->getId()] <
+                    lowestDisc[neighborNode->getId()]) {
+                  result.bridges.emplace_back(*edge);
+                }
+              }
+
+              if ((typeMask & TARJAN_FIND_CUTV) && (nodeIsAdded == false)) {
+                if (curNode->getId() == rootId) {
+                  numSon++;
+                  // a root node is a cut vertices only when it connects at
+                  // least two connected components
+                  if (numSon == 2) {
+                    nodeIsAdded = true;
+                    result.cutVertices.emplace_back(*curNode);
+                  }
+                } else {
+                  if (discoveryTime[curNode->getId()] <=
+                      lowestDisc[neighborNode->getId()]) {
+                    nodeIsAdded = true;
+                    result.cutVertices.emplace_back(*curNode);
+                  }
+                }
+              }
+
+              if (typeMask & TARJAN_FIND_VBCC) {
+                if (discoveryTime[curNode->getId()] <=
+                    lowestDisc[neighborNode->getId()]) {
+                  // if current node is a cut vertice or the root node, the vbcc
+                  // a vertice-biconnect-component which contains the neighbor
+                  // node
+                  std::vector<Node<T>> vbcc;
+                  while (true) {
+                    // pop a top node out of stack until
+                    // the neighbor node has been poped out
+                    Node<T> nodeAtTop = sccNodeStack.top();
+                    vbccNodeStack.pop();
+                    vbcc.emplace_back(nodeAtTop);
+                    if (nodeAtTop == *neighborNode) {
+                      break;
+                    }
+                  }
+                  vbcc.emplace_back(*curNode);
+                  result.verticeBiconnectedComps.emplace_back(std::move(vbcc));
+                }
+              }
+            } else if ((edge != prevEdge) &&
+                       ((isDirected == false) ||
+                        (inStack.count(neighborNode->getId())))) {
+              // it's not allowed to go through the previous edge back
+              // for a directed graph, it's also not allowed to visit
+              // a node that is not in stack
+              lowestDisc[curNode->getId()] =
+                  std::min(lowestDisc[curNode->getId()],
+                           lowestDisc[neighborNode->getId()]);
+            }
+          }
+        }
+        // find sccs for a undirected graph is very similar with
+        // find ebccs for a directed graph
+        if ((typeMask & TARJAN_FIND_SCC) || (typeMask & TARJAN_FIND_EBCC)) {
+          std::stack<Node<T>> &nodeStack =
+              (typeMask & TARJAN_FIND_SCC) ? sccNodeStack : ebccNodeStack;
+          if (discoveryTime[curNode->getId()] == lowestDisc[curNode->getId()]) {
+            std::vector<Node<T>> connectedComp;
+            while (true) {
+              // pop a top node out of stack until
+              // the current node has been poped out
+              Node<T> nodeAtTop = nodeStack.top();
+              nodeStack.pop();
+              connectedComp.emplace_back(nodeAtTop);
+              if (nodeAtTop == *curNode) {
+                break;
+              }
+            }
+            // store this component in result
+            (typeMask & TARJAN_FIND_SCC)
+                ? result.stronglyConnectedComps.emplace_back(
+                      std::move(connectedComp))
+                : result.edgeBiconnectedComps.emplace_back(
+                      std::move(connectedComp));
+          }
+        }
+      };
+
+  for (const auto &node : nodeSet) {
+    if (!discoveryTime.count(node->getId())) {
+      rootId = node->getId();
+      dfs_helper(node, nullptr);
+    }
+  }
+
+  return result;
 }
 
 template <typename T>

--- a/include/Utility/Typedef.hpp
+++ b/include/Utility/Typedef.hpp
@@ -26,6 +26,8 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "ConstValue.hpp"
 #include "PointerHash.hpp"
@@ -35,10 +37,10 @@ namespace CXXGraph {
 template <typename T>
 using unique = std::unique_ptr<T>;
 template <typename T>
-using shared= std::shared_ptr<T>;
+using shared = std::shared_ptr<T>;
 
-using std::make_unique;
 using std::make_shared;
+using std::make_unique;
 
 template <typename T>
 class Node;
@@ -62,6 +64,14 @@ enum E_InputOutputFormat {
 
 typedef E_InputOutputFormat InputOutputFormat;
 
+/// specify the type of results returnde by tarjan's algorithm
+enum TarjanAlgorithmTypes {
+  TARJAN_FIND_SCC = (1 << 0),
+  TARJAN_FIND_CUTV = (1 << 1),
+  TARJAN_FIND_BRIDGE = (1 << 2),
+  TARJAN_FIND_VBCC = (1 << 3),
+  TARJAN_FIND_EBCC = (1 << 4)
+};
 /////////////////////////////////////////////////////
 // Structures ///////////////////////////////////////
 
@@ -190,6 +200,35 @@ struct SCCResult_struct {
 template <typename T>
 using SCCResult = SCCResult_struct<T>;
 
+/// Struct that contains the information about TopologicalSort's Algorithm
+/// results
+template <typename T>
+struct TarjanResult_struct {
+  bool success =
+      false;  // TRUE if the function does not return error, FALSE otherwise
+  std::string errorMessage = "";  // message of error
+  Components<T>
+      stronglyConnectedComps;  // vectors that store nodes belong to same SCC
+                               // (valid only if a graph is directed and flag
+                               // TARJAN_FIND_SCC is set)
+  Components<T>
+      verticeBiconnectedComps;  // vectors that store nodes belong to same v-bcc
+                                // (valid only if a graph is undirected and flag
+                                // TARJAN_FIND_VBCC is set)
+  Components<T>
+      edgeBiconnectedComps;  // vectors that store nodes belong to same e-bcc
+                             // (valid only if a graph is undirected and flag
+                             // TARJAN_FIND_EBCC is set)
+  std::vector<Node<T>> cutVertices;  // a vector that stores cut vertices
+                                     // (valid only is a graph is undirected and
+                                     // flag TARJAN_FIND_CUTV is set)
+  std::vector<Edge<T>> bridges;  // a vector that stores bridges
+                                 // (valid only is a graph is undirected and
+                                 // flag TRAJAN_FIND_BRIDGES is set)
+};
+template <typename T>
+using TarjanResult = TarjanResult_struct<T>;
+
 /// Struct that contains the information about Best First Search Algorithm
 /// results
 template <typename T>
@@ -209,7 +248,9 @@ using BestFirstSearchResult = BestFirstSearchResult_struct<T>;
 
 template <typename T>
 using AdjacencyMatrix = std::unordered_map<
-    shared<const Node<T>>, std::vector<std::pair<shared<const Node<T>>, shared<const Edge<T>>>>, nodeHash<T>>;
+    shared<const Node<T>>,
+    std::vector<std::pair<shared<const Node<T>>, shared<const Edge<T>>>>,
+    nodeHash<T>>;
 
 template <typename T>
 using PartitionMap =

--- a/test/TarjanTest.cpp
+++ b/test/TarjanTest.cpp
@@ -1,0 +1,113 @@
+#include <random>
+#include <vector>
+
+#include "CXXGraph.hpp"
+#include "Utility/ConstString.hpp"
+#include "Utility/Typedef.hpp"
+#include "gtest/gtest.h"
+
+// Smart pointers alias
+template <typename T>
+using unique = std::unique_ptr<T>;
+template <typename T>
+using shared = std::shared_ptr<T>;
+
+using std::make_shared;
+
+TEST(TarjanTest, test_1) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, node1, node2, 1);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node2, node3, 1);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge2));
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::TarjanResult<int> res = graph.tarjan(CXXGraph::TARJAN_FIND_SCC);
+  ASSERT_EQ(res.success, true);
+  ASSERT_EQ(res.stronglyConnectedComps.size(), 3);
+  ASSERT_EQ(res.stronglyConnectedComps[0].size(), 1);
+  ASSERT_EQ(res.stronglyConnectedComps[1].size(), 1);
+  ASSERT_EQ(res.stronglyConnectedComps[2].size(), 1);
+  // check whether nodes in the result are different from each other and are all
+  // real nodes in the graph
+  auto scc1 = res.stronglyConnectedComps[0][0];
+  auto scc2 = res.stronglyConnectedComps[1][0];
+  auto scc3 = res.stronglyConnectedComps[2][0];
+  ASSERT_EQ((scc1 == scc2) || (scc2 == scc3) || (scc1 == scc3), false);
+  int equalCount = 0;
+  if ((scc1 == node1) || (scc1 == node2) || (scc1 == node3)) {
+    equalCount++;
+  }
+  if ((scc2 == node1) || (scc2 == node2) || (scc2 == node3)) {
+    equalCount++;
+  }
+  if ((scc3 == node1) || (scc3 == node2) || (scc3 == node3)) {
+    equalCount++;
+  }
+  ASSERT_EQ(equalCount, 3);
+  // check whether other types of functions are not be executed
+  ASSERT_EQ(res.cutVertices.size(), 0);
+  ASSERT_EQ(res.edgeBiconnectedComps.size(), 0);
+  ASSERT_EQ(res.verticeBiconnectedComps.size(), 0);
+}
+
+TEST(TarjanTest, test_2) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  CXXGraph::Node<int> node7("7", 7);
+  CXXGraph::Node<int> node8("8", 8);
+  CXXGraph::Node<int> node9("9", 9);
+  std::vector<CXXGraph::DirectedWeightedEdge<int>> edges{
+      {1, node1, node2, 1},  {2, node2, node1, 1},  {3, node1, node3, 1},
+      {4, node3, node1, 1},  {5, node2, node4, 1},  {6, node3, node4, 1},
+      {7, node5, node4, 1},  {8, node4, node5, 1},  {9, node6, node2, 1},
+      {10, node7, node6, 1}, {11, node6, node8, 1}, {12, node8, node7, 1},
+      {13, node6, node5, 1}, {14, node8, node5, 1}, {15, node9, node7, 1},
+      {16, node9, node8, 1},
+  };
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  for (const auto &edge : edges) {
+    edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge));
+  }
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::TarjanResult<int> res = graph.tarjan(CXXGraph::TARJAN_FIND_SCC);
+  ASSERT_EQ(res.success, true);
+  ASSERT_EQ(res.stronglyConnectedComps.size(), 4);
+  // sort scc by size
+  std::sort(res.stronglyConnectedComps.begin(),
+            res.stronglyConnectedComps.end(),
+            [&](const auto &scc1, const auto &scc2) {
+              if ((scc1.size() == scc2.size()) && (scc1.size() > 0)) {
+                return scc1[0].getData() < scc2[0].getData();
+              }
+              return scc1.size() < scc2.size();
+            });
+  // sort nodes in a scc by node id
+  for (auto &scc : res.stronglyConnectedComps) {
+    sort(scc.begin(), scc.end(), [&](const auto &node1, const auto &node2) {
+      return node1.getData() < node2.getData();
+    });
+    printf("Scc:\n");
+    for (int i = 0; i < scc.size(); ++i) {
+      printf("id %lu, data %lu\n", scc[i].getId(), scc[i].getData());
+    }
+  }
+  std::vector<std::vector<CXXGraph::Node<int>>> expectRes{
+      {node9}, {node4, node5}, {node1, node2, node3}, {node6, node7, node8}};
+  for (int i = 0; i < 4; ++i) {
+    ASSERT_EQ(res.stronglyConnectedComps[i].size(), expectRes[i].size());
+    for (int j = 0; j < expectRes[i].size(); ++j) {
+      ASSERT_EQ(res.stronglyConnectedComps[i][j], expectRes[i][j]);
+    }
+  }
+  // check whether other types of functions are not be executed
+  ASSERT_EQ(res.cutVertices.size(), 0);
+  ASSERT_EQ(res.edgeBiconnectedComps.size(), 0);
+  ASSERT_EQ(res.verticeBiconnectedComps.size(), 0);
+}

--- a/test/TarjanTest.cpp
+++ b/test/TarjanTest.cpp
@@ -49,6 +49,7 @@ TEST(TarjanTest, test_1) {
   ASSERT_EQ(equalCount, 3);
   // check whether other types of functions are not be executed
   ASSERT_EQ(res.cutVertices.size(), 0);
+  ASSERT_EQ(res.bridges.size(), 0);
   ASSERT_EQ(res.edgeBiconnectedComps.size(), 0);
   ASSERT_EQ(res.verticeBiconnectedComps.size(), 0);
 }
@@ -93,10 +94,6 @@ TEST(TarjanTest, test_2) {
     sort(scc.begin(), scc.end(), [&](const auto &node1, const auto &node2) {
       return node1.getData() < node2.getData();
     });
-    printf("Scc:\n");
-    for (int i = 0; i < scc.size(); ++i) {
-      printf("id %lu, data %lu\n", scc[i].getId(), scc[i].getData());
-    }
   }
   std::vector<std::vector<CXXGraph::Node<int>>> expectRes{
       {node9}, {node4, node5}, {node1, node2, node3}, {node6, node7, node8}};
@@ -108,6 +105,271 @@ TEST(TarjanTest, test_2) {
   }
   // check whether other types of functions are not be executed
   ASSERT_EQ(res.cutVertices.size(), 0);
+  ASSERT_EQ(res.bridges.size(), 0);
   ASSERT_EQ(res.edgeBiconnectedComps.size(), 0);
   ASSERT_EQ(res.verticeBiconnectedComps.size(), 0);
+}
+
+TEST(TarjanTest, test_3) {
+  // the undirected graph used in this case is a block-cut tree in wiki
+  // https://en.wikipedia.org/wiki/Biconnected_component#/media/File:Block-cut_tree2.svg
+  std::vector<CXXGraph::Node<int>> nodes;
+  nodes.emplace_back("0", 0);
+  for (int i = 1; i <= 18; ++i) {
+    nodes.emplace_back(std::to_string(i), i);
+  };
+  std::vector<std::pair<int,int>> pairs{
+    {1, 2}, {2, 3}, {3, 4}, {2, 4}, {2, 5}, {2, 6},
+    {5, 6}, {5, 7}, {6, 7}, {7, 8}, {7, 11}, {8, 11},
+    {8, 9}, {9, 11}, {8, 12}, {8, 14}, {8, 15}, 
+    {12, 13}, {14, 13}, {15, 13}, {9, 10}, {11, 10}, 
+    {10, 16}, {10, 17}, {10, 18}, {17, 18}
+  };
+  std::vector<CXXGraph::UndirectedWeightedEdge<int>> edges;
+  for (const auto& [id1, id2] : pairs) {
+    edges.emplace_back(edges.size() + 1, nodes[id1], nodes[id2], 1);
+  }
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  for (const auto &edge : edges) {
+    edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge));
+  }
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::TarjanResult<int> res = graph.tarjan(CXXGraph::TARJAN_FIND_CUTV);
+  ASSERT_EQ(res.success, true);
+
+  std::vector<int> expectRes{2, 7, 8, 10};
+  ASSERT_EQ(res.cutVertices.size(), expectRes.size());
+  std::sort(res.cutVertices.begin(), res.cutVertices.end(), [&](const auto &node1, const auto &node2) {
+      return node1.getData() < node2.getData();
+  });
+  for (int i = 0; i < expectRes.size(); ++i) {
+    ASSERT_EQ(res.cutVertices[i], nodes[expectRes[i]]);
+  }
+  // check whether other types of functions are not be executed
+  ASSERT_EQ(res.stronglyConnectedComps.size(), 0);
+  ASSERT_EQ(res.bridges.size(), 0);
+  ASSERT_EQ(res.edgeBiconnectedComps.size(), 0);
+  ASSERT_EQ(res.verticeBiconnectedComps.size(), 0);
+}
+
+TEST(TarjanTest, test_4) {
+  // the undirected graph used in this case is a block-cut tree in wiki
+  // https://en.wikipedia.org/wiki/Biconnected_component#/media/File:Block-cut_tree2.svg
+  std::vector<CXXGraph::Node<int>> nodes;
+  nodes.emplace_back("0", 0);
+  for (int i = 1; i <= 18; ++i) {
+    nodes.emplace_back(std::to_string(i), i);
+  };
+  std::vector<std::pair<int,int>> pairs{
+    {1, 2}, {2, 3}, {3, 4}, {2, 4}, {2, 5}, {2, 6},
+    {5, 6}, {5, 7}, {6, 7}, {7, 8}, {7, 11}, {8, 11},
+    {8, 9}, {9, 11}, {8, 12}, {8, 14}, {8, 15}, 
+    {12, 13}, {14, 13}, {15, 13}, {9, 10}, {11, 10}, 
+    {10, 16}, {10, 17}, {10, 18}, {17, 18}
+  };
+  std::vector<CXXGraph::UndirectedWeightedEdge<int>> edges;
+  for (const auto& [id1, id2] : pairs) {
+    edges.emplace_back(edges.size() + 1, nodes[id1], nodes[id2], 1);
+  }
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  for (const auto &edge : edges) {
+    edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge));
+  }
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::TarjanResult<int> res = graph.tarjan(CXXGraph::TARJAN_FIND_VBCC);
+  ASSERT_EQ(res.success, true);
+
+  std::vector<std::vector<CXXGraph::Node<int>>> expectRes{
+      {nodes[1], nodes[2]}, {nodes[2], nodes[3], nodes[4]}, 
+      {nodes[2], nodes[5], nodes[6], nodes[7]}, 
+      {nodes[7], nodes[8], nodes[9], nodes[10], nodes[11]},
+      {nodes[8], nodes[12], nodes[13], nodes[14], nodes[15]},
+      {nodes[10], nodes[16]},
+      {nodes[10], nodes[17], nodes[18]}
+  };
+  ASSERT_EQ(res.verticeBiconnectedComps.size(), expectRes.size());
+
+  // sort nodes in a vbcc by node id
+  for (auto &vbcc : res.verticeBiconnectedComps) {
+    sort(vbcc.begin(), vbcc.end(), [&](const auto &node1, const auto &node2) {
+      return node1.getData() < node2.getData();
+    });
+  }
+  // sort vbccs by first node and size
+  std::sort(res.verticeBiconnectedComps.begin(),
+            res.verticeBiconnectedComps.end(),
+            [&](const auto &scc1, const auto &scc2) {
+              if ((scc1.size() == 0) || (scc2.size() == 0) || (scc1[0].getData() == scc2[0].getData())) {
+                return scc1.size() < scc2.size();
+              }
+              return scc1[0].getData() < scc2[0].getData(); 
+            });
+  for (int i = 0; i < res.verticeBiconnectedComps.size(); ++i) {
+    ASSERT_EQ(res.verticeBiconnectedComps[i].size(), expectRes[i].size());
+    for (int j = 0; j < expectRes[i].size(); ++j) {
+      ASSERT_EQ(res.verticeBiconnectedComps[i][j], expectRes[i][j]);
+    }
+  }
+  // check whether other types of functions are not be executed
+  ASSERT_EQ(res.stronglyConnectedComps.size(), 0);
+  ASSERT_EQ(res.bridges.size(), 0);
+  ASSERT_EQ(res.edgeBiconnectedComps.size(), 0);
+  ASSERT_EQ(res.cutVertices.size(), 0);
+}
+
+
+TEST(TarjanTest, test_5) {
+  // the undirected graph used in this case is a bridge tree from a tutorial on codeforce
+  // https://codeforces.com/blog/entry/99259
+  std::vector<CXXGraph::Node<int>> nodes;
+  nodes.emplace_back("0", 0);
+  for (int i = 1; i <= 12; ++i) {
+    nodes.emplace_back(std::to_string(i), i);
+  };
+  std::vector<std::pair<int,int>> pairs{
+    {1, 2}, {2, 3}, {1, 3}, {3, 4}, {3, 9}, 
+    {4, 5}, {5, 6}, {4, 7}, {6, 7}, {6, 8}, 
+    {7, 8}, {9, 10}, {9, 11}, {10, 12}, {11, 12},
+  };
+  std::vector<CXXGraph::UndirectedWeightedEdge<int>> edges;
+  for (const auto& [id1, id2] : pairs) {
+    edges.emplace_back(edges.size() + 1, nodes[id1], nodes[id2], 1);
+  }
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  for (const auto &edge : edges) {
+    edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge));
+  }
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::TarjanResult<int> res = graph.tarjan(CXXGraph::TARJAN_FIND_BRIDGE);
+  ASSERT_EQ(res.success, true);
+
+  std::vector<int> expectRes{3, 4};
+  ASSERT_EQ(res.bridges.size(), expectRes.size());
+  std::sort(res.bridges.begin(), res.bridges.end(), [&](const auto &edge1, const auto &edge2) {
+      return edge1.getId() < edge2.getId();
+  });
+  for (int i = 0; i < expectRes.size(); ++i) {
+    ASSERT_EQ(res.bridges[i], edges[expectRes[i]]);
+  }
+  // check whether other types of functions are not be executed
+  ASSERT_EQ(res.stronglyConnectedComps.size(), 0);
+  ASSERT_EQ(res.cutVertices.size(), 0);
+  ASSERT_EQ(res.edgeBiconnectedComps.size(), 0);
+  ASSERT_EQ(res.verticeBiconnectedComps.size(), 0);
+}
+
+TEST(TarjanTest, test_6) {
+  // the undirected graph used in this case is a bridge tree from a tutorial on codeforce
+  // https://codeforces.com/blog/entry/99259
+  std::vector<CXXGraph::Node<int>> nodes;
+  nodes.emplace_back("0", 0);
+  for (int i = 1; i <= 12; ++i) {
+    nodes.emplace_back(std::to_string(i), i);
+  };
+  std::vector<std::pair<int,int>> pairs{
+    {1, 2}, {2, 3}, {1, 3}, {3, 4}, {3, 9}, 
+    {4, 5}, {5, 6}, {4, 7}, {6, 7}, {6, 8}, 
+    {7, 8}, {9, 10}, {9, 11}, {10, 12}, {11, 12},
+  };
+  std::vector<CXXGraph::UndirectedWeightedEdge<int>> edges;
+  for (const auto& [id1, id2] : pairs) {
+    edges.emplace_back(edges.size() + 1, nodes[id1], nodes[id2], 1);
+  }
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  for (const auto &edge : edges) {
+    edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge));
+  }
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::TarjanResult<int> res = graph.tarjan(CXXGraph::TARJAN_FIND_EBCC);
+  ASSERT_EQ(res.success, true);
+
+  std::vector<std::vector<CXXGraph::Node<int>>> expectRes{
+      {nodes[1], nodes[2], nodes[3]}, 
+      {nodes[4], nodes[5], nodes[6], nodes[7], nodes[8]}, 
+      {nodes[9], nodes[10], nodes[11], nodes[12]}
+  };
+  ASSERT_EQ(res.edgeBiconnectedComps.size(), expectRes.size());
+
+  // sort nodes in a vbcc by node id
+  for (auto &ebcc : res.edgeBiconnectedComps) {
+    sort(ebcc.begin(), ebcc.end(), [&](const auto &node1, const auto &node2) {
+      return node1.getData() < node2.getData();
+    });
+  }
+  // sort vbccs by first node and size
+  std::sort(res.edgeBiconnectedComps.begin(),
+            res.edgeBiconnectedComps.end(),
+            [&](const auto &scc1, const auto &scc2) {
+              if ((scc1.size() == 0) || (scc2.size() == 0) || (scc1[0].getData() == scc2[0].getData())) {
+                return scc1.size() < scc2.size();
+              }
+              return scc1[0].getData() < scc2[0].getData(); 
+            });
+  for (int i = 0; i < res.edgeBiconnectedComps.size(); ++i) {
+    ASSERT_EQ(res.edgeBiconnectedComps[i].size(), expectRes[i].size());
+    for (int j = 0; j < expectRes[i].size(); ++j) {
+      ASSERT_EQ(res.edgeBiconnectedComps[i][j], expectRes[i][j]);
+    }
+  }
+  // check whether other types of functions are not be executed
+  ASSERT_EQ(res.stronglyConnectedComps.size(), 0);
+  ASSERT_EQ(res.bridges.size(), 0);
+  ASSERT_EQ(res.verticeBiconnectedComps.size(), 0);
+  ASSERT_EQ(res.cutVertices.size(), 0);
+}
+
+TEST(TarjanTest, test_7) {
+  // the undirected graph used in this case is a block-cut tree in wiki
+  // https://en.wikipedia.org/wiki/Biconnected_component#/media/File:Block-cut_tree2.svg
+  std::vector<CXXGraph::Node<int>> nodes;
+  nodes.emplace_back("0", 0);
+  for (int i = 1; i <= 18; ++i) {
+    nodes.emplace_back(std::to_string(i), i);
+  };
+  std::vector<std::pair<int,int>> pairs{
+    {1, 2}, {2, 3}, {3, 4}, {2, 4}, {2, 5}, {2, 6},
+    {5, 6}, {5, 7}, {6, 7}, {7, 8}, {7, 11}, {8, 11},
+    {8, 9}, {9, 11}, {8, 12}, {8, 14}, {8, 15}, 
+    {12, 13}, {14, 13}, {15, 13}, {9, 10}, {11, 10}, 
+    {10, 16}, {10, 17}, {10, 18}, {17, 18}
+  };
+  std::vector<CXXGraph::UndirectedWeightedEdge<int>> edges;
+  for (const auto& [id1, id2] : pairs) {
+    edges.emplace_back(edges.size() + 1, nodes[id1], nodes[id2], 1);
+  }
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  for (const auto &edge : edges) {
+    edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge));
+  }
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  CXXGraph::TarjanResult<int> cutvRes = graph.tarjan(CXXGraph::TARJAN_FIND_CUTV);
+  CXXGraph::TarjanResult<int> bridgeRes = graph.tarjan(CXXGraph::TARJAN_FIND_BRIDGE);
+  CXXGraph::TarjanResult<int> vbccRes = graph.tarjan(CXXGraph::TARJAN_FIND_VBCC);
+  CXXGraph::TarjanResult<int> ebccRes = graph.tarjan(CXXGraph::TARJAN_FIND_EBCC);
+  CXXGraph::TarjanResult<int> res = graph.tarjan(CXXGraph::TARJAN_FIND_CUTV | CXXGraph::TARJAN_FIND_BRIDGE | CXXGraph::TARJAN_FIND_EBCC | CXXGraph::TARJAN_FIND_VBCC);
+  ASSERT_EQ(res.success, true);
+
+  ASSERT_EQ(res.cutVertices.size(), cutvRes.cutVertices.size());
+  for (int i = 0; i < cutvRes.cutVertices.size(); ++i) {
+    ASSERT_EQ(cutvRes.cutVertices[i], res.cutVertices[i]);
+  }
+  ASSERT_EQ(res.bridges.size(), bridgeRes.bridges.size());
+  for (int i = 0; i < bridgeRes.cutVertices.size(); ++i) {
+    ASSERT_EQ(bridgeRes.bridges[i], res.bridges[i]);
+  }
+  ASSERT_EQ(res.edgeBiconnectedComps.size(), ebccRes.edgeBiconnectedComps.size());
+  for (int i = 0; i < res.edgeBiconnectedComps.size(); ++i) {
+    ASSERT_EQ(res.edgeBiconnectedComps[i].size(), ebccRes.edgeBiconnectedComps[i].size());
+    for (int j = 0; j < ebccRes.edgeBiconnectedComps[i].size(); ++j) {
+      ASSERT_EQ(res.edgeBiconnectedComps[i][j], ebccRes.edgeBiconnectedComps[i][j]);
+    }
+  }
+  ASSERT_EQ(res.verticeBiconnectedComps.size(), vbccRes.verticeBiconnectedComps.size());
+  for (int i = 0; i < res.verticeBiconnectedComps.size(); ++i) {
+    ASSERT_EQ(res.verticeBiconnectedComps[i].size(), vbccRes.verticeBiconnectedComps[i].size());
+    for (int j = 0; j < vbccRes.verticeBiconnectedComps[i].size(); ++j) {
+      ASSERT_EQ(res.verticeBiconnectedComps[i][j], vbccRes.verticeBiconnectedComps[i][j]);
+    }
+  }
 }


### PR DESCRIPTION
* implement tarjan's algorithm to find scc for directed graphs
* implement tarjan's algorithm to find cut vertices/bridges/V-Dcc/E-Dcc for undirected graphs
* formatting

There might be different purposes of Tarjan's algorithm, but the basic framework and core idea of it are the same. So I implemented a common function for Tarjan's algorithm which return different results based on the input parameter instead of multiple slightly modified versions of that. 
