### PR TITLE
Edge equality operator is incorrect (#333)

### DIFF
--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <deque>
 #include <fstream>
+#include <sstream>
 #include <functional>
 #include <iostream>
 #include <limits>

--- a/include/Utility/PointerHash.hpp
+++ b/include/Utility/PointerHash.hpp
@@ -69,7 +69,7 @@ template <typename T>
 bool operator==(shared<const Edge<T>> p1, shared<const Edge<T>> p2) {
   return p1->getNodePair().first->getUserId() ==
              p2->getNodePair().first->getUserId() &&
-         p2->getNodePair().second->getUserId() ==
+         p1->getNodePair().second->getUserId() ==
              p2->getNodePair().second->getUserId();
 }
 }  // namespace CXXGraph

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,7 @@ if(TEST)
         PUBLIC ${zlib_BINARY_DIR}
         PUBLIC ${zlib_SOURCE_DIR}
     )
+
     target_link_libraries(test_exe
         PUBLIC GTest::gtest_main
         PUBLIC zlibstatic

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -168,7 +168,6 @@ TEST(GraphTest, DirectedEdgeCycle_1) {
   CXXGraph::DirectedEdge<int> edge2(1, node2, node1);
   CXXGraph::DirectedEdge<int> edge3(2, node3, node1);
 
-  CXXGraph::Graph<int> graph;
   graph.addEdge(&edge1);
   graph.addEdge(&edge2);
   graph.addEdge(&edge3);
@@ -196,6 +195,41 @@ TEST(GraphTest, DirectedEdgeCycle_2) {
   // Check that all of the edges have been added to the graph
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
 }
+
+TEST(GraphTest, DirectedEdge_hashequality) {
+  CXXGraph::Node<int> node1("node1 (0)", 0);
+  CXXGraph::Node<int> node2("node2 (1)", 1);
+  CXXGraph::Node<int> node3("node3 (2)", 2);
+  CXXGraph::Node<int> node4("node4 (3)", 3);
+  CXXGraph::Node<int> node5("node5 (4)", 4);
+  CXXGraph::Node<int> node6("node6 (5)", 5);
+  CXXGraph::Node<int> node7("node7 (6)", 6);
+
+  CXXGraph::DirectedEdge<int> edge1(0, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(1, node2, node3);
+  CXXGraph::DirectedEdge<int> edge3(3, node5, node4);
+  CXXGraph::DirectedEdge<int> edge4(4, node5, node3);
+  CXXGraph::DirectedEdge<int> edge5(5, node5, node2);
+  CXXGraph::DirectedEdge<int> edge6(6, node5, node6);
+  CXXGraph::DirectedEdge<int> edge7(7, node5, node1);
+  CXXGraph::DirectedEdge<int> edge8(8, node5, node7);
+  CXXGraph::DirectedEdge<int> edge9(9, node3, node4);
+  CXXGraph::DirectedEdge<int> edge10(10, node6, node2);
+  CXXGraph::DirectedEdge<int> edge11(11, node7, node2);
+
+  CXXGraph::Graph<int> graph;
+
+  graph.addEdge(&edge4);
+  graph.addEdge(&edge5);
+  graph.addEdge(&edge6);
+  graph.addEdge(&edge7);
+  graph.addEdge(&edge8);
+  graph.addEdge(&edge9);
+  graph.addEdge(&edge10);
+  graph.addEdge(&edge11);
+
+  // Check that all of the edges have been added to the graph
+  ASSERT_EQ(graph.getEdgeSet().size(), 11);
 
 TEST(GraphTest, adj_print_1) {
   CXXGraph::Node<int> node1("1", 1);

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -168,6 +168,8 @@ TEST(GraphTest, DirectedEdgeCycle_1) {
   CXXGraph::DirectedEdge<int> edge2(1, node2, node1);
   CXXGraph::DirectedEdge<int> edge3(2, node3, node1);
 
+  CXXGraph::Graph<int> graph;
+
   graph.addEdge(&edge1);
   graph.addEdge(&edge2);
   graph.addEdge(&edge3);
@@ -217,8 +219,6 @@ TEST(GraphTest, DirectedEdge_hashequality) {
   CXXGraph::DirectedEdge<int> edge10(10, node6, node2);
   CXXGraph::DirectedEdge<int> edge11(11, node7, node2);
 
-  CXXGraph::Graph<int> graph;
-
   CXXGraph::T_EdgeSet<int> edges;
   auto addEdge = [&](CXXGraph::DirectedEdge<int>& edge)
   {
@@ -233,18 +233,19 @@ TEST(GraphTest, DirectedEdge_hashequality) {
     }
   };
 
-  addEdge(&edge1);
-  addEdge(&edge2);
-  addEdge(&edge3);
-  addEdge(&edge4);
-  addEdge(&edge5);
-  addEdge(&edge6);
-  addEdge(&edge7);
-  addEdge(&edge8);
-  addEdge(&edge9);
-  addEdge(&edge10);
-  addEdge(&edge11);
+  addEdge(edge1);
+  addEdge(edge2);
+  addEdge(edge3);
+  addEdge(edge4);
+  addEdge(edge5);
+  addEdge(edge6);
+  addEdge(edge7);
+  addEdge(edge8);
+  addEdge(edge9);
+  addEdge(edge10);
+  addEdge(edge11);
 
+  CXXGraph::Graph<int> graph;
   graph.setEdgeSet(edges);
 
   // Check that all of the edges have been added to the graph

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -219,14 +219,33 @@ TEST(GraphTest, DirectedEdge_hashequality) {
 
   CXXGraph::Graph<int> graph;
 
-  graph.addEdge(&edge4);
-  graph.addEdge(&edge5);
-  graph.addEdge(&edge6);
-  graph.addEdge(&edge7);
-  graph.addEdge(&edge8);
-  graph.addEdge(&edge9);
-  graph.addEdge(&edge10);
-  graph.addEdge(&edge11);
+  CXXGraph::T_EdgeSet<int> edges;
+  auto addEdge = [&](CXXGraph::DirectedEdge<int>& edge)
+  {
+    size_t currSize = edges.size();
+    auto sharedEdge = CXXGraph::make_shared<CXXGraph::DirectedEdge<int>>(edge.getId(), edge.getFrom(), edge.getTo());
+    edges.insert(sharedEdge);
+    if ((currSize + 1) != edges.size())
+    {
+      std::cout << "Skipped " << edge.getNodePair().first->getUserId() << " --> " << edge.getNodePair().second->getUserId() << " (hash: " << CXXGraph::edgeHash<int>{}(sharedEdge) << ")" << std::endl;
+    } else {
+      std::cout << "Added " << edge.getNodePair().first->getUserId() << " --> " << edge.getNodePair().second->getUserId() << " (hash: " << CXXGraph::edgeHash<int>{}(sharedEdge) << ")" << std::endl;
+    }
+  };
+
+  addEdge(&edge1);
+  addEdge(&edge2);
+  addEdge(&edge3);
+  addEdge(&edge4);
+  addEdge(&edge5);
+  addEdge(&edge6);
+  addEdge(&edge7);
+  addEdge(&edge8);
+  addEdge(&edge9);
+  addEdge(&edge10);
+  addEdge(&edge11);
+
+  graph.setEdgeSet(edges);
 
   // Check that all of the edges have been added to the graph
   ASSERT_EQ(graph.getEdgeSet().size(), 11);

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -230,6 +230,7 @@ TEST(GraphTest, DirectedEdge_hashequality) {
 
   // Check that all of the edges have been added to the graph
   ASSERT_EQ(graph.getEdgeSet().size(), 11);
+}
 
 TEST(GraphTest, adj_print_1) {
   CXXGraph::Node<int> node1("1", 1);


### PR DESCRIPTION
Demonstration that unique edges are "skipped" sometimes when adding to an `EdgeSet_T`. Wonder if it's hashing, equality, or user error?

Running this on my machine:
![image](https://github.com/ZigRazor/CXXGraph/assets/11186620/263fe258-3dd9-4ab5-a320-4718e77df24b)

Which makes me believe we have a bug, are misunderstanding how `std::unordered_set` works, or I'm doing something silly.

Let me know what you guys think! @sbaldu @ZigRazor 


# Update

After much sleuthing, I've found the error to be innocuously hidden [here](https://github.com/ZigRazor/CXXGraph/blob/7afc54ece0d0c9991d051560bde12afcc6ce1d88/include/Utility/PointerHash.hpp#L72).

It turns out our edge equality operator was incorrect. This causes the underlying hash bucket implemented by various STL incarnations to incorrectly match nodes that are otherwise proven unique (by our hashing function, but STL implementors sometimes check equality anyway).

(As an aside, maybe we should look at a better hash implementation. The bitwise xor ( ^ ) doesn't work for edges that use the same nodes (cycles) since the operation is mathematically symmetrical) - this can result in performance degradation in highly cyclical graphs. Copying boost::hash_combine seems like a good candidate)