### PR TITLE
Migrate from CMake FetchContent to CMake Package Manager (CPM)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,23 @@ if(DEBUG)
 	)
 endif(DEBUG)
 
+# set up CPM.cmake
+if(CPM_SOURCE_CACHE)
+	set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+	set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM.cmake")
+else()
+	set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM.cmake")
+endif()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+	message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+	file(DOWNLOAD
+    	https://github.com/cpm-cmake/CPM.cmake/releases/latest/download/CPM.cmake
+    	${CPM_DOWNLOAD_LOCATION}
+	)
+endif()
+
 add_subdirectory(test)
 add_subdirectory(benchmark)
 add_subdirectory(examples)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -2,36 +2,27 @@ option(BENCHMARK "Enable Benchmark" OFF)
 option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
 
 if(BENCHMARK)
+	include(${CPM_DOWNLOAD_LOCATION})
 
-	include(FetchContent)
-
-	FetchContent_Declare(
-		googletest
-		GIT_REPOSITORY https://github.com/google/googletest.git
+	CPMAddPackage(
+		NAME googletest
+		GITHUB_REPOSITORY google/googletest
 		GIT_TAG origin/main
-		#GIT_TAG        v1.13.0 # release-1.13.0
+		OPTIONS "gtest_forced_shared_crt ON"
 	)
 
-	FetchContent_Declare(
-		googlebenchmark
-		GIT_REPOSITORY https://github.com/google/benchmark.git
+	CPMAddPackage(
+		NAME googlebenchmark
+		GITHUB_REPOSITORY google/benchmark
 		GIT_TAG origin/main
 	)
 
-	FetchContent_Declare(
-		zlib
-		GIT_REPOSITORY https://github.com/madler/zlib.git
-		GIT_TAG v1.2.13
+	CPMAddPackage(
+		NAME zlib
+		GITHUB_REPOSITORY madler/zlib
+		VERSION 1.2.13
+		OPTIONS "CMAKE_POSITION_INDEPENDENT_CODE True"
 	)
-
-	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-	FetchContent_MakeAvailable(googletest)
-	FetchContent_MakeAvailable(googlebenchmark)
-
-	set(SAVE_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
-	set(CMAKE_POSITION_INDEPENDENT_CODE True)
-	FetchContent_MakeAvailable(zlib)
-	set(CMAKE_POSITION_INDEPENDENT_CODE ${SAVE_CMAKE_POSITION_INDEPENDENT_CODE})
 
 	file (GLOB BENCHMARK_FILES "*.cpp" "*.hpp")
 	add_executable(benchmark_exe ${BENCHMARK_FILES})

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -8,7 +8,7 @@ if(BENCHMARK)
 		NAME googletest
 		GITHUB_REPOSITORY google/googletest
 		GIT_TAG origin/main
-		OPTIONS "gtest_forced_shared_crt ON"
+		OPTIONS "gtest_forced_shared_crt ON CACHE BOOL "" FORCE"
 	)
 
 	CPMAddPackage(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,18 +28,17 @@ if(TEST)
         NAME googletest
         GITHUB_REPOSITORY google/googletest
         GIT_TAG origin/main
-        OPTIONS "gtest_forced_shared_crt ON"
+        OPTIONS "gtest_forced_shared_crt ON CACHE BOOL "" FORCE"
     )
 
     CPMAddPackage(
         NAME zlib
         GITHUB_REPOSITORY madler/zlib
-		VERSION 1.2.13
-		OPTIONS "CMAKE_POSITION_INDEPENDENT_CODE True"
+        VERSION 1.2.13
+        OPTIONS "CMAKE_POSITION_INDEPENDENT_CODE True"
     )
 
     file (GLOB TEST_FILES "*.cpp" "*.hpp")
-
     add_executable(test_exe ${TEST_FILES})
 
     target_compile_definitions(test_exe

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,28 +22,21 @@ endif(CODE_COVERAGE)
 
 option(TEST "Enable Test" OFF)
 if(TEST)
-    include(FetchContent)
+    include(${CPM_DOWNLOAD_LOCATION})
 
-    FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
+    CPMAddPackage(
+        NAME googletest
+        GITHUB_REPOSITORY google/googletest
         GIT_TAG origin/main
-        #GIT_TAG        v1.13.0 # release-1.13.0
+        OPTIONS "gtest_forced_shared_crt ON"
     )
 
-    FetchContent_Declare(
-        zlib
-        GIT_REPOSITORY https://github.com/madler/zlib.git
-        GIT_TAG v1.2.13
+    CPMAddPackage(
+        NAME zlib
+        GITHUB_REPOSITORY madler/zlib
+		VERSION 1.2.13
+		OPTIONS "CMAKE_POSITION_INDEPENDENT_CODE True"
     )
-
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
-
-    set(SAVE_CMAKE_POSITION_INDEPENDENT_CODE ${CMAKE_POSITION_INDEPENDENT_CODE})
-    set(CMAKE_POSITION_INDEPENDENT_CODE True)
-    FetchContent_MakeAvailable(zlib)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ${SAVE_CMAKE_POSITION_INDEPENDENT_CODE})
 
     file (GLOB TEST_FILES "*.cpp" "*.hpp")
 


### PR DESCRIPTION
This pull request migrates the project from using CMake FetchContent to CMake Package Manager (CPM).
Related Issue: Closes #286 

Changes Made:
- Updated main CMakeLists.txt to fetch latest CPM.cmake script on execution
- Removed FetchContent-related commands from benchmark/CMakeLists.txt and test/CMakeLists.txt

Testing:
- I have tested the changes locally and ensured that the project builds successfully using CMake 3.24 on Ubuntu 22.04.
- I have verified that the correct versions of the packages are being fetched by CPM. 