### PR TITLE
Reduce warnings from CMake

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -8,7 +8,7 @@ if(BENCHMARK)
 		NAME googletest
 		GITHUB_REPOSITORY google/googletest
 		GIT_TAG origin/main
-		OPTIONS "gtest_forced_shared_crt ON CACHE BOOL "" FORCE"
+		OPTIONS "gtest_forced_shared_crt ON CACHE BOOL FORCE"
 	)
 
 	CPMAddPackage(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,7 @@ if(TEST)
         NAME googletest
         GITHUB_REPOSITORY google/googletest
         GIT_TAG origin/main
-        OPTIONS "gtest_forced_shared_crt ON CACHE BOOL "" FORCE"
+        OPTIONS "gtest_forced_shared_crt ON CACHE BOOL FORCE"
     )
 
     CPMAddPackage(


### PR DESCRIPTION
Fixes the syntax on these lines so that CMake doesn't warn us about commands with parameters next to eachother.
