### PR TITLE
[Fix] [Issue 338] Inconsistent id types

### DIFF
--- a/include/Edge/DirectedEdge.hpp
+++ b/include/Edge/DirectedEdge.hpp
@@ -45,13 +45,13 @@ std::ostream &operator<<(std::ostream &o, const DirectedEdge<T> &edge);
 template <typename T>
 class DirectedEdge : public Edge<T> {
  public:
-  DirectedEdge(const unsigned long id, const Node<T> &node1,
+  DirectedEdge(const CXXGraph::id_t id, const Node<T> &node1,
                const Node<T> &node2);
-  DirectedEdge(const unsigned long id, shared<const Node<T>> node1,
+  DirectedEdge(const CXXGraph::id_t id, shared<const Node<T>> node1,
                shared<const Node<T>> node2);
-  DirectedEdge(const unsigned long id,
+  DirectedEdge(const CXXGraph::id_t id,
                const std::pair<const Node<T> *, const Node<T> *> &nodepair);
-  DirectedEdge(const unsigned long id,
+  DirectedEdge(const CXXGraph::id_t id,
                const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair);
   DirectedEdge(const Edge<T> &edge);
   virtual ~DirectedEdge() = default;
@@ -69,23 +69,23 @@ class DirectedEdge : public Edge<T> {
 };
 
 template <typename T>
-DirectedEdge<T>::DirectedEdge(const unsigned long id, const Node<T> &node1,
+DirectedEdge<T>::DirectedEdge(const CXXGraph::id_t id, const Node<T> &node1,
                               const Node<T> &node2)
     : Edge<T>(id, node1, node2) {}
 
 template <typename T>
-DirectedEdge<T>::DirectedEdge(const unsigned long id, shared<const Node<T>> node1,
+DirectedEdge<T>::DirectedEdge(const CXXGraph::id_t id, shared<const Node<T>> node1,
 			 shared<const Node<T>> node2) : Edge<T>(id, node1, node2) {}
 
 template <typename T>
 DirectedEdge<T>::DirectedEdge(
-    const unsigned long id,
+    const CXXGraph::id_t id,
     const std::pair<const Node<T> *, const Node<T> *> &nodepair)
     : Edge<T>(id, nodepair) {}
 
 template <typename T>
 DirectedEdge<T>::DirectedEdge(
-    const unsigned long id,
+    const CXXGraph::id_t id,
     const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair)
     : Edge<T>(id, nodepair) {}
 

--- a/include/Edge/DirectedWeightedEdge.hpp
+++ b/include/Edge/DirectedWeightedEdge.hpp
@@ -48,16 +48,16 @@ std::ostream &operator<<(std::ostream &o, const DirectedWeightedEdge<T> &edge);
 template <typename T>
 class DirectedWeightedEdge : public DirectedEdge<T>, public Weighted {
  public:
-  DirectedWeightedEdge(const unsigned long id, const Node<T> &node1,
+  DirectedWeightedEdge(const CXXGraph::id_t id, const Node<T> &node1,
                        const Node<T> &node2, const double weight);
-  DirectedWeightedEdge(const unsigned long id, shared<const Node<T>> node1,
+  DirectedWeightedEdge(const CXXGraph::id_t id, shared<const Node<T>> node1,
                        shared<const Node<T>> node2, const double weight);
   DirectedWeightedEdge(
-      const unsigned long id,
+      const CXXGraph::id_t id,
       const std::pair<const Node<T> *, const Node<T> *> &nodepair,
       const double weight);
   DirectedWeightedEdge(
-      const unsigned long id,
+      const CXXGraph::id_t id,
       const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair,
       const double weight);
   DirectedWeightedEdge(const DirectedEdge<T> &edge, const double weight);
@@ -78,14 +78,14 @@ class DirectedWeightedEdge : public DirectedEdge<T>, public Weighted {
 };
 
 template <typename T>
-DirectedWeightedEdge<T>::DirectedWeightedEdge(const unsigned long id,
+DirectedWeightedEdge<T>::DirectedWeightedEdge(const CXXGraph::id_t id,
                                               const Node<T> &node1,
                                               const Node<T> &node2,
                                               const double weight)
     : DirectedEdge<T>(id, node1, node2), Weighted(weight) {}
 
 template <typename T>
-DirectedWeightedEdge<T>::DirectedWeightedEdge(const unsigned long id,
+DirectedWeightedEdge<T>::DirectedWeightedEdge(const CXXGraph::id_t id,
                                               shared<const Node<T>> node1,
                                               shared<const Node<T>> node2,
                                               const double weight)
@@ -93,14 +93,14 @@ DirectedWeightedEdge<T>::DirectedWeightedEdge(const unsigned long id,
 
 template <typename T>
 DirectedWeightedEdge<T>::DirectedWeightedEdge(
-    const unsigned long id,
+    const CXXGraph::id_t id,
     const std::pair<const Node<T> *, const Node<T> *> &nodepair,
     const double weight)
     : DirectedEdge<T>(id, nodepair), Weighted(weight) {}
 
 template <typename T>
 DirectedWeightedEdge<T>::DirectedWeightedEdge(
-    const unsigned long id,
+    const CXXGraph::id_t id,
     const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair,
     const double weight)
     : DirectedEdge<T>(id, nodepair), Weighted(weight) {}

--- a/include/Edge/Edge.hpp
+++ b/include/Edge/Edge.hpp
@@ -27,6 +27,7 @@
 #include <utility>
 
 #include "Node/Node.hpp"
+#include "Utility/id_t.hpp"
 
 namespace CXXGraph {
 // Smart pointers alias
@@ -46,15 +47,15 @@ std::ostream &operator<<(std::ostream &o, const Edge<T> &edge);
 template <typename T>
 class Edge {
  private:
-  unsigned long long id = 0;
+  CXXGraph::id_t id = 0;
   std::pair<shared<const Node<T>>, shared<const Node<T>>> nodePair;
 
  public:
-  Edge(const unsigned long long id, const Node<T> &node1, const Node<T> &node2);
-  Edge(const unsigned long long id, shared<const Node<T>> node1, shared<const Node<T>> node2);
-  Edge(const unsigned long long id,
+  Edge(const CXXGraph::id_t id, const Node<T> &node1, const Node<T> &node2);
+  Edge(const CXXGraph::id_t id, shared<const Node<T>> node1, shared<const Node<T>> node2);
+  Edge(const CXXGraph::id_t id,
        const std::pair<const Node<T> *, const Node<T> *> &nodepair);
-  Edge(const unsigned long long id,
+  Edge(const CXXGraph::id_t id,
        const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair);
   virtual ~Edge() = default;
   void setFirstNode(shared<const Node<T>> node);
@@ -75,7 +76,7 @@ class Edge {
 };
 
 template <typename T>
-Edge<T>::Edge(const unsigned long long id, const Node<T> &node1,
+Edge<T>::Edge(const CXXGraph::id_t id, const Node<T> &node1,
               const Node<T> &node2) {
   this->nodePair.first = make_shared<const Node<T>>(node1);
   this->nodePair.second = make_shared<const Node<T>>(node2);
@@ -83,14 +84,14 @@ Edge<T>::Edge(const unsigned long long id, const Node<T> &node1,
 }
 
 template <typename T>
-Edge<T>::Edge(const unsigned long long id, shared<const Node<T>> node1, shared<const Node<T>> node2) {
+Edge<T>::Edge(const CXXGraph::id_t id, shared<const Node<T>> node1, shared<const Node<T>> node2) {
   this->nodePair.first = node1;
   this->nodePair.second = node2;
   this->id = id;
 }
 
 template <typename T>
-Edge<T>::Edge(const unsigned long long id,
+Edge<T>::Edge(const CXXGraph::id_t id,
               const std::pair<const Node<T> *, const Node<T> *> &nodepair) {
   this->nodePair.first = make_shared<const Node<T>>(*(nodepair.first));
   this->nodePair.second = make_shared<const Node<T>>(*(nodepair.second));
@@ -98,7 +99,7 @@ Edge<T>::Edge(const unsigned long long id,
 }
 
 template <typename T>
-Edge<T>::Edge(const unsigned long long id,
+Edge<T>::Edge(const CXXGraph::id_t id,
               const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair)
     : nodePair(nodepair) {
   this->id = id;

--- a/include/Edge/Edge.hpp
+++ b/include/Edge/Edge.hpp
@@ -60,7 +60,7 @@ class Edge {
   virtual ~Edge() = default;
   void setFirstNode(shared<const Node<T>> node);
   void setSecondNode(shared<const Node<T>> node);
-  const unsigned long long &getId() const;
+  const unsigned long long getId() const;
   const std::pair<shared<const Node<T>>, shared<const Node<T>>> &getNodePair() const;
   shared<const Node<T>> getOtherNode(shared<const Node<T>> node) const;
   virtual const std::optional<bool> isDirected() const;
@@ -118,7 +118,7 @@ void Edge<T>::setSecondNode(shared<const Node<T>> node) {
 }
 
 template <typename T>
-const unsigned long long &Edge<T>::getId() const {
+const unsigned long long Edge<T>::getId() const {
   return id;
 }
 

--- a/include/Edge/UndirectedEdge.hpp
+++ b/include/Edge/UndirectedEdge.hpp
@@ -44,13 +44,13 @@ std::ostream &operator<<(std::ostream &o, const UndirectedEdge<T> &edge);
 template <typename T>
 class UndirectedEdge : public Edge<T> {
  public:
-  UndirectedEdge(const unsigned long id, const Node<T> &node1,
+  UndirectedEdge(const CXXGraph::id_t id, const Node<T> &node1,
                  const Node<T> &node2);
-  UndirectedEdge(const unsigned long id, shared<const Node<T>> node1,
+  UndirectedEdge(const CXXGraph::id_t id, shared<const Node<T>> node1,
                  shared<const Node<T>> node2);
-  UndirectedEdge(const unsigned long id,
+  UndirectedEdge(const CXXGraph::id_t id,
                  const std::pair<const Node<T> *, const Node<T> *> &nodepair);
-  UndirectedEdge(const unsigned long id,
+  UndirectedEdge(const CXXGraph::id_t id,
                  const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair);
   UndirectedEdge(const Edge<T> &edge);
   virtual ~UndirectedEdge() = default;
@@ -68,24 +68,24 @@ class UndirectedEdge : public Edge<T> {
 };
 
 template <typename T>
-UndirectedEdge<T>::UndirectedEdge(const unsigned long id, const Node<T> &node1,
+UndirectedEdge<T>::UndirectedEdge(const CXXGraph::id_t id, const Node<T> &node1,
                                   const Node<T> &node2)
     : Edge<T>(id, node1, node2) {}
 
 template <typename T>
-UndirectedEdge<T>::UndirectedEdge(const unsigned long id, shared<const Node<T>> node1,
+UndirectedEdge<T>::UndirectedEdge(const CXXGraph::id_t id, shared<const Node<T>> node1,
                                   shared<const Node<T>> node2)
     : Edge<T>(id, node1, node2) {}
 
 template <typename T>
 UndirectedEdge<T>::UndirectedEdge(
-    const unsigned long id,
+    const CXXGraph::id_t id,
     const std::pair<const Node<T> *, const Node<T> *> &nodepair)
     : Edge<T>(id, nodepair) {}
 
 template <typename T>
 UndirectedEdge<T>::UndirectedEdge(
-    const unsigned long id,
+    const CXXGraph::id_t id,
     const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair)
     : Edge<T>(id, nodepair) {}
 

--- a/include/Edge/UndirectedWeightedEdge.hpp
+++ b/include/Edge/UndirectedWeightedEdge.hpp
@@ -50,16 +50,16 @@ std::ostream &operator<<(std::ostream &o,
 template <typename T>
 class UndirectedWeightedEdge : public UndirectedEdge<T>, public Weighted {
  public:
-  UndirectedWeightedEdge(const unsigned long id, const Node<T> &node1,
+  UndirectedWeightedEdge(const CXXGraph::id_t id, const Node<T> &node1,
                          const Node<T> &node2, const double weight);
-  UndirectedWeightedEdge(const unsigned long id, shared<const Node<T>> node1,
+  UndirectedWeightedEdge(const CXXGraph::id_t id, shared<const Node<T>> node1,
                          shared<const Node<T>> node2, const double weight);
   UndirectedWeightedEdge(
-      const unsigned long id,
+      const CXXGraph::id_t id,
       const std::pair<const Node<T> *, const Node<T> *> &nodepair,
       const double weight);
   UndirectedWeightedEdge(
-      const unsigned long id,
+      const CXXGraph::id_t id,
       const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair,
       const double weight);
   UndirectedWeightedEdge(const UndirectedEdge<T> &edge, const double weight);
@@ -80,14 +80,14 @@ class UndirectedWeightedEdge : public UndirectedEdge<T>, public Weighted {
 };
 
 template <typename T>
-UndirectedWeightedEdge<T>::UndirectedWeightedEdge(const unsigned long id,
+UndirectedWeightedEdge<T>::UndirectedWeightedEdge(const CXXGraph::id_t id,
                                                   const Node<T> &node1,
                                                   const Node<T> &node2,
                                                   const double weight)
     : UndirectedEdge<T>(id, node1, node2), Weighted(weight) {}
 
 template <typename T>
-UndirectedWeightedEdge<T>::UndirectedWeightedEdge(const unsigned long id,
+UndirectedWeightedEdge<T>::UndirectedWeightedEdge(const CXXGraph::id_t id,
                                                   shared<const Node<T>> node1,
                                                   shared<const Node<T>> node2,
                                                   const double weight)
@@ -95,14 +95,14 @@ UndirectedWeightedEdge<T>::UndirectedWeightedEdge(const unsigned long id,
 
 template <typename T>
 UndirectedWeightedEdge<T>::UndirectedWeightedEdge(
-    const unsigned long id,
+    const CXXGraph::id_t id,
     const std::pair<const Node<T> *, const Node<T> *> &nodepair,
     const double weight)
     : UndirectedEdge<T>(id, nodepair), Weighted(weight) {}
 
 template <typename T>
 UndirectedWeightedEdge<T>::UndirectedWeightedEdge(
-    const unsigned long id,
+    const CXXGraph::id_t id,
     const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair,
     const double weight)
     : UndirectedEdge<T>(id, nodepair), Weighted(weight) {}

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -2688,17 +2688,17 @@ const TarjanResult<T> Graph<T>::tarjan(const unsigned int typeMask) const {
 
   const auto &adjMatrix = getAdjMatrix();
   const auto &nodeSet = getNodeSet();
-  std::unordered_map<size_t, int>
+  std::unordered_map<CXXGraph::id_t, int>
       discoveryTime;  // the timestamp when a node is visited
-  std::unordered_map<size_t, int>
+  std::unordered_map<CXXGraph::id_t, int>
       lowestDisc;  // the lowest discovery time of all
                    // reachable nodes from current node
   int timestamp = 0;
-  size_t rootId = 0;
+  CXXGraph::id_t rootId = 0;
   std::stack<Node<T>> sccNodeStack;
   std::stack<Node<T>> ebccNodeStack;
   std::stack<Node<T>> vbccNodeStack;
-  std::unordered_set<size_t> inStack;
+  std::unordered_set<CXXGraph::id_t> inStack;
   std::function<void(const shared<const Node<T>>, const shared<const Edge<T>>)>
       dfs_helper = [this, typeMask, isDirected, &dfs_helper, &adjMatrix,
                     &discoveryTime, &lowestDisc, &timestamp, &rootId,
@@ -2894,7 +2894,7 @@ TopoSortResult<T> Graph<T>::kahn() const {
     const auto nodeSet = Graph<T>::getNodeSet();
     result.nodesInTopoOrder.reserve(adjMatrix->size());
 
-    std::unordered_map<size_t, unsigned int> indegree;
+    std::unordered_map<CXXGraph::id_t, unsigned int> indegree;
     for (const auto &node : nodeSet) {
       indegree[node->getId()] = 0;
     }

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -116,11 +116,11 @@ class Graph {
                  const std::string &graphName) const;
   int readFromDot(const std::string &workingDir, const std::string &fileName);
   void recreateGraph(
-      std::unordered_map<unsigned long long,
+      std::unordered_map<CXXGraph::id_t,
                          std::pair<std::string, std::string>> &edgeMap,
-      std::unordered_map<unsigned long long, bool> &edgeDirectedMap,
+      std::unordered_map<CXXGraph::id_t, bool> &edgeDirectedMap,
       std::unordered_map<std::string, T> &nodeFeatMap,
-      std::unordered_map<unsigned long long, double> &edgeWeightMap);
+      std::unordered_map<CXXGraph::id_t, double> &edgeWeightMap);
 
 #ifdef WITH_COMPRESSION
   int compressFile(const std::string &inputFile,
@@ -181,7 +181,7 @@ class Graph {
    * @param edgeId The Edge Id to remove
    *
    */
-  virtual void removeEdge(const unsigned long long edgeId);
+  virtual void removeEdge(const CXXGraph::id_t edgeId);
   /**
    * \brief
    * Finds the given edge defined by v1 and v2 within the graph.
@@ -192,7 +192,7 @@ class Graph {
    * @return True if the edge exists in the graph.
    */
   virtual bool findEdge(const Node<T> *v1, const Node<T> *v2,
-                        unsigned long long &id) const;
+                        CXXGraph::id_t &id) const;
   /**
    * \brief
    * Overload of findEdge which takes shared pointers as parameters
@@ -203,7 +203,7 @@ class Graph {
    * @return True if the edge exists in the graph.
    */
   virtual bool findEdge(shared<const Node<T>> v1, shared<const Node<T>> v2,
-                        unsigned long long &id) const;
+                        CXXGraph::id_t &id) const;
   /**
    * \brief
    * Function that return the Node Set of the Graph
@@ -241,7 +241,7 @@ class Graph {
    *
    */
   virtual const std::optional<shared<const Edge<T>>> getEdge(
-      const unsigned long long edgeId) const;
+      const CXXGraph::id_t edgeId) const;
   /**
    * @brief This function generate a list of adjacency matrix with every element
    * of the matrix contain the node where is directed the link and the Edge
@@ -296,9 +296,9 @@ class Graph {
    * @return parent node of elem
    * Note: No Thread Safe
    */
-  virtual unsigned long long setFind(
-      std::unordered_map<unsigned long long, Subset> *,
-      const unsigned long long elem) const;
+  virtual CXXGraph::id_t setFind(
+      std::unordered_map<CXXGraph::id_t, Subset> *,
+      const CXXGraph::id_t elem) const;
   /**
    * @brief This function finds the subset of given a nodeId
    * Subset is stored in a map where keys are the hash-id of the node & values
@@ -310,9 +310,9 @@ class Graph {
    * @return parent node of elem
    * Note: No Thread Safe
    */
-  virtual unsigned long long setFind(
-      shared<std::unordered_map<unsigned long long, Subset>>,
-      const unsigned long long elem) const;
+  virtual CXXGraph::id_t setFind(
+      shared<std::unordered_map<CXXGraph::id_t, Subset>>,
+      const CXXGraph::id_t elem) const;
   /**
    * @brief This function modifies the original subset array
    * such that it the union of two sets a and b
@@ -322,9 +322,9 @@ class Graph {
    * NOTE: Original subset is no longer available after union.
    * Note: No Thread Safe
    */
-  virtual void setUnion(std::unordered_map<unsigned long long, Subset> *,
-                        const unsigned long long set1,
-                        const unsigned long long elem2) const;
+  virtual void setUnion(std::unordered_map<CXXGraph::id_t, Subset> *,
+                        const CXXGraph::id_t set1,
+                        const CXXGraph::id_t elem2) const;
   /**
    * @brief This function modifies the original subset array
    * such that it the union of two sets a and b
@@ -334,9 +334,9 @@ class Graph {
    * NOTE: Original subset is no longer available after union.
    * Note: No Thread Safe
    */
-  virtual void setUnion(shared<std::unordered_map<unsigned long long, Subset>>,
-                        const unsigned long long set1,
-                        const unsigned long long elem2) const;
+  virtual void setUnion(shared<std::unordered_map<CXXGraph::id_t, Subset>>,
+                        const CXXGraph::id_t set1,
+                        const CXXGraph::id_t elem2) const;
   /**
    * @brief This function finds the eulerian path of a directed graph using
    * hierholzers algorithm
@@ -538,7 +538,7 @@ class Graph {
    */
   virtual bool containsCycle(
       shared<const T_EdgeSet<T>> edgeSet,
-      shared<std::unordered_map<unsigned long long, Subset>>) const;
+      shared<std::unordered_map<CXXGraph::id_t, Subset>>) const;
 
   /**
    * \brief
@@ -780,7 +780,7 @@ void Graph<T>::addEdge(shared<const Edge<T>> edge) {
 }
 
 template <typename T>
-void Graph<T>::removeEdge(const unsigned long long edgeId) {
+void Graph<T>::removeEdge(const CXXGraph::id_t edgeId) {
   auto edgeOpt = Graph<T>::getEdge(edgeId);
   if (edgeOpt.has_value()) {
     /*
@@ -793,7 +793,7 @@ void Graph<T>::removeEdge(const unsigned long long edgeId) {
 
 template <typename T>
 bool Graph<T>::findEdge(const Node<T> *v1, const Node<T> *v2,
-                        unsigned long long &id) const {
+                        CXXGraph::id_t &id) const {
   auto v1_shared = make_shared<const Node<T>>(*v1);
   auto v2_shared = make_shared<const Node<T>>(*v2);
 
@@ -802,7 +802,7 @@ bool Graph<T>::findEdge(const Node<T> *v1, const Node<T> *v2,
 
 template <typename T>
 bool Graph<T>::findEdge(shared<const Node<T>> v1, shared<const Node<T>> v2,
-                        unsigned long long &id) const {
+                        CXXGraph::id_t &id) const {
   // This could be made faster by looking for the edge hash, assuming we hash
   // based on node data, instead of a unique integer
   for (auto e : this->edgeSet) {
@@ -867,7 +867,7 @@ void Graph<T>::setNodeData(std::map<std::string, T> &dataMap) {
 
 template <typename T>
 const std::optional<shared<const Edge<T>>> Graph<T>::getEdge(
-    const unsigned long long edgeId) const {
+    const CXXGraph::id_t edgeId) const {
   for (const auto &it : edgeSet) {
     if (it->getId() == edgeId) {
       return it;
@@ -1012,13 +1012,13 @@ void Graph<T>::readGraphFromStream(std::istream &iGraph,
                                    std::istream &iNodeFeat,
                                    std::istream &iEdgeWeight, bool readNodeFeat,
                                    bool readEdgeWeight) {
-  std::unordered_map<unsigned long long, std::pair<std::string, std::string>>
+  std::unordered_map<CXXGraph::id_t, std::pair<std::string, std::string>>
       edgeMap;
-  std::unordered_map<unsigned long long, bool> edgeDirectedMap;
+  std::unordered_map<CXXGraph::id_t, bool> edgeDirectedMap;
   std::unordered_map<std::string, T> nodeFeatMap;
-  std::unordered_map<unsigned long long, double> edgeWeightMap;
+  std::unordered_map<CXXGraph::id_t, double> edgeWeightMap;
 
-  unsigned long long edgeId;
+  CXXGraph::id_t edgeId;
   std::string nodeId1;
   std::string nodeId2;
   bool directed;
@@ -1037,7 +1037,7 @@ void Graph<T>::readGraphFromStream(std::istream &iGraph,
   }
 
   if (readEdgeWeight) {
-    unsigned long long edgeId;
+    CXXGraph::id_t edgeId;
     double weight;
     bool weighted;
     while (iEdgeWeight >> edgeId >> weight >> weighted) { /* loop continually */
@@ -1054,11 +1054,11 @@ template <typename T>
 int Graph<T>::readFromDot(const std::string &workingDir,
                           const std::string &fileName) {
   // Define the edge maps
-  std::unordered_map<unsigned long long, std::pair<std::string, std::string>>
+  std::unordered_map<CXXGraph::id_t, std::pair<std::string, std::string>>
       edgeMap;
   std::unordered_map<std::string, T> nodeFeatMap;
-  std::unordered_map<unsigned long long, bool> edgeDirectedMap;
-  std::unordered_map<unsigned long long, double> edgeWeightMap;
+  std::unordered_map<CXXGraph::id_t, bool> edgeDirectedMap;
+  std::unordered_map<CXXGraph::id_t, double> edgeWeightMap;
 
   // Define the node strings and the "garbage collector" temp string
   std::string node1;
@@ -1088,7 +1088,7 @@ int Graph<T>::readFromDot(const std::string &workingDir,
   // Write the header of the DOT file in the temp string
   getline(iFile, temp);
 
-  unsigned long long edgeId = 0;
+  CXXGraph::id_t edgeId = 0;
   std::string fileRow;
   while (getline(iFile, fileRow)) {
     // If you've reached the end of the file, stop
@@ -1135,11 +1135,11 @@ int Graph<T>::readFromDot(const std::string &workingDir,
 
 template <typename T>
 void Graph<T>::recreateGraph(
-    std::unordered_map<unsigned long long, std::pair<std::string, std::string>>
+    std::unordered_map<CXXGraph::id_t, std::pair<std::string, std::string>>
         &edgeMap,
-    std::unordered_map<unsigned long long, bool> &edgeDirectedMap,
+    std::unordered_map<CXXGraph::id_t, bool> &edgeDirectedMap,
     std::unordered_map<std::string, T> &nodeFeatMap,
-    std::unordered_map<unsigned long long, double> &edgeWeightMap) {
+    std::unordered_map<CXXGraph::id_t, double> &edgeWeightMap) {
   std::unordered_map<std::string, shared<Node<T>>> nodeMap;
   for (const auto &edgeIt : edgeMap) {
     shared<Node<T>> node1(nullptr);
@@ -1212,7 +1212,7 @@ int Graph<T>::compressFile(const std::string &inputFile,
   }
 
   unsigned int zippedBytes;
-  zippedBytes = gzwrite(outFileZ, content_ptr, strlen(content_ptr));
+  zippedBytes = gzwrite(outFileZ, content_ptr, (unsigned int)strlen(content_ptr));
 
   ifs.close();
   gzclose(outFileZ);
@@ -1256,11 +1256,11 @@ int Graph<T>::decompressFile(const std::string &inputFile,
 #endif
 
 template <typename T>
-unsigned long long Graph<T>::setFind(
-    std::unordered_map<unsigned long long, Subset> *subsets,
-    const unsigned long long nodeId) const {
+CXXGraph::id_t Graph<T>::setFind(
+    std::unordered_map<CXXGraph::id_t, Subset> *subsets,
+    const CXXGraph::id_t nodeId) const {
   auto subsets_ptr =
-      make_shared<std::unordered_map<unsigned long long, Subset>>(*subsets);
+      make_shared<std::unordered_map<CXXGraph::id_t, Subset>>(*subsets);
   // find root and make root as parent of i
   // (path compression)
   if ((*subsets)[nodeId].parent != nodeId) {
@@ -1272,9 +1272,9 @@ unsigned long long Graph<T>::setFind(
 }
 
 template <typename T>
-unsigned long long Graph<T>::setFind(
-    shared<std::unordered_map<unsigned long long, Subset>> subsets,
-    const unsigned long long nodeId) const {
+CXXGraph::id_t Graph<T>::setFind(
+    shared<std::unordered_map<CXXGraph::id_t, Subset>> subsets,
+    const CXXGraph::id_t nodeId) const {
   // find root and make root as parent of i
   // (path compression)
   if ((*subsets)[nodeId].parent != nodeId) {
@@ -1286,10 +1286,10 @@ unsigned long long Graph<T>::setFind(
 }
 
 template <typename T>
-void Graph<T>::setUnion(std::unordered_map<unsigned long long, Subset> *subsets,
-                        const unsigned long long elem1,
-                        const unsigned long long elem2) const {
-  /* auto subsets_ptr = make_shared<std::unordered_map<unsigned long long,
+void Graph<T>::setUnion(std::unordered_map<CXXGraph::id_t, Subset> *subsets,
+                        const CXXGraph::id_t elem1,
+                        const CXXGraph::id_t elem2) const {
+  /* auto subsets_ptr = make_shared<std::unordered_map<CXXGraph::id_t,
    * Subset>>(*subsets); */
   // if both sets have same parent
   // then there's nothing to be done
@@ -1321,8 +1321,8 @@ void Graph<T>::setUnion(std::unordered_map<unsigned long long, Subset> *subsets,
 
 template <typename T>
 void Graph<T>::setUnion(
-    shared<std::unordered_map<unsigned long long, Subset>> subsets,
-    const unsigned long long elem1, const unsigned long long elem2) const {
+    shared<std::unordered_map<CXXGraph::id_t, Subset>> subsets,
+    const CXXGraph::id_t elem1, const CXXGraph::id_t elem2) const {
   // if both sets have same parent
   // then there's nothing to be done
   if ((*subsets)[elem1].parent == (*subsets)[elem2].parent) return;
@@ -1491,7 +1491,7 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
   }
   const auto adj = getAdjMatrix();
   // n denotes the number of vertices in graph
-  int n = adj->size();
+  auto n = adj->size();
 
   // setting all the distances initially to INF_DOUBLE
   std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
@@ -1703,7 +1703,7 @@ template <typename T>
 const Graph<T> Graph<T>::transitiveReduction() const {
   Graph<T> result(this->edgeSet);
 
-  unsigned long long edgeId = 0;
+  CXXGraph::id_t edgeId = 0;
   std::unordered_set<shared<const Node<T>>, nodeHash<T>> nodes =
       this->getNodeSet();
   for (auto x : nodes) {
@@ -1834,13 +1834,13 @@ const MstResult Graph<T>::prim() const {
   auto source = *(nodeSet.begin());
   pq.push(std::make_pair(0.0, source));
   result.mstCost = 0;
-  std::vector<unsigned long long> doneNode;
+  std::vector<CXXGraph::id_t> doneNode;
   // mark source node as done
   // otherwise we get (0, 0) also in mst
   doneNode.push_back(source->getId());
   // stores the parent and corresponding child node
   // of the edges that are part of MST
-  std::unordered_map<unsigned long long, std::string> parentNode;
+  std::unordered_map<CXXGraph::id_t, std::string> parentNode;
   while (!pq.empty()) {
     // second element of pair denotes the node / vertex
     shared<const Node<T>> currentNode = pq.top().second;
@@ -1896,16 +1896,16 @@ const MstResult Graph<T>::boruvka() const {
   const auto n = nodeSet.size();
 
   // Use std map for storing n subsets.
-  auto subsets = make_shared<std::unordered_map<unsigned long long, Subset>>();
+  auto subsets = make_shared<std::unordered_map<CXXGraph::id_t, Subset>>();
 
   // Initially there are n different trees.
   // Finally there will be one tree that will be MST
-  int numTrees = n;
+  auto numTrees = n;
 
   // check if all edges are weighted and store the weights
   // in a map whose keys are the edge ids and values are the edge weights
   const auto edgeSet = Graph<T>::getEdgeSet();
-  std::unordered_map<unsigned long long, double> edgeWeight;
+  std::unordered_map<CXXGraph::id_t, double> edgeWeight;
   for (const auto &edge : edgeSet) {
     if (edge->isWeighted().has_value() && edge->isWeighted().value())
       edgeWeight[edge->getId()] =
@@ -1927,7 +1927,7 @@ const MstResult Graph<T>::boruvka() const {
   while (numTrees > 1) {
     // Everytime initialize cheapest map
     // It stores index of the cheapest edge of subset.
-    std::unordered_map<unsigned long long, unsigned long long> cheapest;
+    std::unordered_map<CXXGraph::id_t, CXXGraph::id_t> cheapest;
     for (const auto &node : nodeSet) cheapest[node->getId()] = INT_MAX;
 
     // Traverse through all edges and update
@@ -2009,7 +2009,7 @@ const MstResult Graph<T>::kruskal() const {
     }
   }
 
-  auto subset = make_shared<std::unordered_map<unsigned long long, Subset>>();
+  auto subset = make_shared<std::unordered_map<CXXGraph::id_t, Subset>>();
 
   for (const auto &node : nodeSet) {
     Subset set{node->getId(), 0};
@@ -2158,11 +2158,11 @@ const std::vector<Node<T>> Graph<T>::concurrency_breadth_first_search(
     return bfs_result;
   }
 
-  std::unordered_map<shared<const Node<T>>, int, nodeHash<T>> node_to_index;
+  std::unordered_map<shared<const Node<T>>, size_t, nodeHash<T>> node_to_index;
   for (const auto &node : nodeSet) {
     node_to_index[node] = node_to_index.size();
   }
-  std::vector<int> visited(nodeSet.size(), 0);
+  std::vector<size_t> visited(nodeSet.size(), 0);
 
   // parameter limitations
   if (num_threads <= 0) {
@@ -2234,7 +2234,7 @@ const std::vector<Node<T>> Graph<T>::concurrency_breadth_first_search(
         for (int i = start_index; i < end_index; ++i) {
           if (adj->count(level_tracker[i])) {
             for (const auto &elem : adj->at(level_tracker[i])) {
-              int index = node_to_index[elem.first];
+              int index = (int)node_to_index[elem.first];
               if (visited[index] == 0) {
                 visited[index] = 1;
                 local_tracker.push_back(elem.first);
@@ -2265,7 +2265,7 @@ const std::vector<Node<T>> Graph<T>::concurrency_breadth_first_search(
           block_size = 16;
         }
 
-        num_tasks = level_tracker.size();
+        num_tasks = (int)level_tracker.size();
         waiting_workers = 0;
         assigned_tasks = 0;
         level = level + 1;
@@ -2352,7 +2352,7 @@ bool Graph<T>::isCyclicDirectedGraphDFS() const {
    *
    * Initially, all nodes are in "not_visited" state.
    */
-  std::unordered_map<unsigned long long, nodeStates> state;
+  std::unordered_map<CXXGraph::id_t, nodeStates> state;
   for (const auto &node : nodeSet) {
     state[node->getId()] = not_visited;
   }
@@ -2366,13 +2366,13 @@ bool Graph<T>::isCyclicDirectedGraphDFS() const {
     if (state[node->getId()] == not_visited) {
       // Check for cycle.
       std::function<bool(const std::shared_ptr<AdjacencyMatrix<T>>,
-                         std::unordered_map<unsigned long long, nodeStates> &,
+                         std::unordered_map<CXXGraph::id_t, nodeStates> &,
                          shared<const Node<T>>)>
           isCyclicDFSHelper;
       isCyclicDFSHelper =
           [this, &isCyclicDFSHelper](
               const std::shared_ptr<AdjacencyMatrix<T>> adjMatrix,
-              std::unordered_map<unsigned long long, nodeStates> &states,
+              std::unordered_map<CXXGraph::id_t, nodeStates> &states,
               shared<const Node<T>> node) {
             // Add node "in_stack" state.
             states[node->getId()] = in_stack;
@@ -2419,11 +2419,11 @@ bool Graph<T>::isCyclicDirectedGraphDFS() const {
 template <typename T>
 bool Graph<T>::containsCycle(const T_EdgeSet<T> *edgeSet) const {
   auto edgeSet_ptr = make_shared<const T_EdgeSet<T>>(*edgeSet);
-  auto subset = make_shared<std::unordered_map<unsigned long long, Subset>>();
+  auto subset = make_shared<std::unordered_map<CXXGraph::id_t, Subset>>();
   // initialize the subset parent and rank values
   for (const auto &edge : *edgeSet_ptr) {
     auto &[first, second] = edge->getNodePair();
-    std::vector<unsigned long long> nodeId(2);
+    std::vector<CXXGraph::id_t> nodeId(2);
     nodeId.push_back(first->getId());
     nodeId.push_back(second->getId());
     for (const auto &id : nodeId) {
@@ -2445,11 +2445,11 @@ bool Graph<T>::containsCycle(const T_EdgeSet<T> *edgeSet) const {
 
 template <typename T>
 bool Graph<T>::containsCycle(shared<const T_EdgeSet<T>> edgeSet) const {
-  auto subset = make_shared<std::unordered_map<unsigned long long, Subset>>();
+  auto subset = make_shared<std::unordered_map<CXXGraph::id_t, Subset>>();
   // initialize the subset parent and rank values
   for (const auto &edge : *edgeSet) {
     auto &[first, second] = edge->getNodePair();
-    std::vector<unsigned long long> nodeId(2);
+    std::vector<CXXGraph::id_t> nodeId(2);
     nodeId.push_back(first->getId());
     nodeId.push_back(second->getId());
     for (const auto &id : nodeId) {
@@ -2472,7 +2472,7 @@ bool Graph<T>::containsCycle(shared<const T_EdgeSet<T>> edgeSet) const {
 template <typename T>
 bool Graph<T>::containsCycle(
     shared<const T_EdgeSet<T>> edgeSet,
-    shared<std::unordered_map<unsigned long long, Subset>> subset) const {
+    shared<std::unordered_map<CXXGraph::id_t, Subset>> subset) const {
   for (const auto &edge : *edgeSet) {
     auto &[first, second] = edge->getNodePair();
     auto set1 = Graph<T>::setFind(subset, first->getId());
@@ -2491,7 +2491,7 @@ bool Graph<T>::isCyclicDirectedGraphBFS() const {
   const auto adjMatrix = Graph<T>::getAdjMatrix();
   auto nodeSet = Graph<T>::getNodeSet();
 
-  std::unordered_map<unsigned long, unsigned int> indegree;
+  std::unordered_map<CXXGraph::id_t, unsigned int> indegree;
   for (const auto &node : nodeSet) {
     indegree[node->getId()] = 0;
   }
@@ -2590,7 +2590,7 @@ bool Graph<T>::isConnectedGraph() const {
     auto nodeSet = getNodeSet();
     const auto adjMatrix = getAdjMatrix();
     // created visited map
-    std::unordered_map<unsigned long, bool> visited;
+    std::unordered_map<CXXGraph::id_t, bool> visited;
     for (const auto &node : nodeSet) {
       visited[node->getId()] = false;
     }
@@ -2631,7 +2631,7 @@ bool Graph<T>::isStronglyConnectedGraph() const {
     const auto adjMatrix = getAdjMatrix();
     for (const auto &start_node : nodeSet) {
       // created visited map
-      std::unordered_map<unsigned long, bool> visited;
+      std::unordered_map<CXXGraph::id_t, bool> visited;
       for (const auto &node : nodeSet) {
         visited[node->getId()] = false;
       }
@@ -2866,7 +2866,7 @@ TopoSortResult<T> Graph<T>::topologicalSort() const {
           result.nodesInTopoOrder.push_back(*curNode);
         };
 
-    int numNodes = adjMatrix->size();
+    auto numNodes = adjMatrix->size();
     result.nodesInTopoOrder.reserve(numNodes);
 
     for (const auto &node : nodeSet) {
@@ -2952,7 +2952,7 @@ SCCResult<T> Graph<T>::kosaraju() const {
     auto nodeSet = getNodeSet();
     const auto adjMatrix = getAdjMatrix();
     // created visited map
-    std::unordered_map<unsigned long, bool> visited;
+    std::unordered_map<CXXGraph::id_t, bool> visited;
     for (const auto &node : nodeSet) {
       visited[node->getId()] = false;
     }
@@ -3057,7 +3057,7 @@ const DialResult Graph<T>::dial(const Node<T> &source, int maxWeight) const {
           in O(1) at time of updation. So
           dist[i].first = distance of ith vertex from src vertex
           dits[i].second = vertex i in bucket number */
-  unsigned int V = nodeSet.size();
+  auto V = nodeSet.size();
   std::unordered_map<shared<const Node<T>>,
                      std::pair<long, shared<const Node<T>>>, nodeHash<T>>
       dist;
@@ -3078,7 +3078,7 @@ const DialResult Graph<T>::dial(const Node<T> &source, int maxWeight) const {
   while (true) {
     // Go sequentially through buckets till one non-empty
     // bucket is found
-    while (B[idx].size() == 0 && idx < maxWeight * V) {
+    while (B[idx].size() == 0u && idx < maxWeight * V) {
       idx++;
     }
 
@@ -3589,11 +3589,11 @@ template <typename T>
 int Graph<T>::readFromMTXFile(const std::string &workingDir,
                               const std::string &fileName) {
   // Define the edge maps
-  std::unordered_map<unsigned long long, std::pair<std::string, std::string>>
+  std::unordered_map<CXXGraph::id_t, std::pair<std::string, std::string>>
       edgeMap;
   std::unordered_map<std::string, T> nodeFeatMap;
-  std::unordered_map<unsigned long long, bool> edgeDirectedMap;
-  std::unordered_map<unsigned long long, double> edgeWeightMap;
+  std::unordered_map<CXXGraph::id_t, bool> edgeDirectedMap;
+  std::unordered_map<CXXGraph::id_t, double> edgeWeightMap;
 
   // Get full path to the file and open it
   const std::string completePathToFileGraph =
@@ -3640,7 +3640,7 @@ int Graph<T>::readFromMTXFile(const std::string &workingDir,
   std::string node1;
   std::string node2;
   std::string edge_weight;
-  unsigned long long edge_id = 0;
+  CXXGraph::id_t edge_id = 0;
   while (getline(iFile, row_content)) {
     std::stringstream row_stream(row_content);
 
@@ -3732,7 +3732,7 @@ std::ostream &operator<<(std::ostream &os, const AdjacencyMatrix<T> &adj) {
   unsigned long max_column = 0;
   for (const auto &it : adj) {
     if (it.second.size() > max_column) {
-      max_column = it.second.size();
+      max_column = (unsigned long)it.second.size();
     }
   }
   if (max_column == 0) {
@@ -3740,7 +3740,7 @@ std::ostream &operator<<(std::ostream &os, const AdjacencyMatrix<T> &adj) {
     return os;
   } else {
     os << "|--|";
-    for (int i = 0; i < max_column; ++i) {
+    for (unsigned long i = 0; i < max_column; ++i) {
       os << "-----|";
     }
     os << "\n";
@@ -3750,7 +3750,7 @@ std::ostream &operator<<(std::ostream &os, const AdjacencyMatrix<T> &adj) {
         os << "N" << it2.first->getId() << ",E" << it2.second->getId() << "|";
       }
       os << "\n|--|";
-      for (int i = 0; i < max_column; ++i) {
+      for (unsigned long i = 0; i < max_column; ++i) {
         os << "-----|";
       }
       os << "\n";

--- a/include/Node/Node.hpp
+++ b/include/Node/Node.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include "Utility/id_t.hpp"
+
 #include <iomanip>
 #include <iostream>
 
@@ -33,7 +35,7 @@ std::ostream &operator<<(std::ostream &os, const Node<T> &node);
 template <typename T>
 class Node {
  private:
-  std::size_t id = 0;
+  CXXGraph::id_t id = 0;
   std::string userId = "";
   T data;
   void setId(const std::string &);
@@ -43,7 +45,7 @@ class Node {
   // Move constructor
   Node(const std::string &, T&& data) noexcept;
   ~Node() = default;
-  const std::size_t &getId() const;
+  const CXXGraph::id_t &getId() const;
   const std::string &getUserId() const;
   const T &getData() const;
   void setData(T&& new_data);
@@ -96,7 +98,7 @@ void Node<T>::setId(const std::string &inpId) {
 }
 
 template <typename T>
-const std::size_t &Node<T>::getId() const {
+const CXXGraph::id_t &Node<T>::getId() const {
   return id;
 }
 

--- a/include/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/Partitioning/CoordinatedPartitionState.hpp
@@ -47,7 +47,7 @@ namespace Partitioning {
 template <typename T>
 class CoordinatedPartitionState : public PartitionState<T> {
  private:
-  std::map<int, std::shared_ptr<CoordinatedRecord<T>>> record_map;
+  std::map<CXXGraph::id_t, std::shared_ptr<CoordinatedRecord<T>>> record_map;
   std::vector<int> machines_load_edges;
   std::vector<double> machines_weight_edges;
   std::vector<int> machines_load_vertices;
@@ -63,7 +63,7 @@ class CoordinatedPartitionState : public PartitionState<T> {
   CoordinatedPartitionState(const Globals &G);
   ~CoordinatedPartitionState();
 
-  std::shared_ptr<Record<T>> getRecord(const int x) override;
+  std::shared_ptr<Record<T>> getRecord(CXXGraph::id_t x) override;
   int getMachineLoad(const int m) const override;
   int getMachineWeight(const int m) const override;
   int getMachineLoadVertices(const int m) const override;
@@ -108,7 +108,7 @@ CoordinatedPartitionState<T>::~CoordinatedPartitionState() {}
 
 template <typename T>
 std::shared_ptr<Record<T>> CoordinatedPartitionState<T>::getRecord(
-    const int x) {
+    CXXGraph::id_t x) {
   std::lock_guard<std::mutex> lock(*record_map_mutex);
   if (record_map.find(x) == record_map.end()) {
     record_map[x] = std::make_shared<CoordinatedRecord<T>>();
@@ -236,7 +236,7 @@ int CoordinatedPartitionState<T>::getTotalReplicas() const {
 template <typename T>
 int CoordinatedPartitionState<T>::getNumVertices() const {
   std::lock_guard<std::mutex> lock(*record_map_mutex);
-  return record_map.size();
+  return (int)record_map.size();
 }
 template <typename T>
 std::set<int> CoordinatedPartitionState<T>::getVertexIds() const {
@@ -244,7 +244,7 @@ std::set<int> CoordinatedPartitionState<T>::getVertexIds() const {
   // if (GLOBALS.OUTPUT_FILE_NAME!=null){ out.close(); }
   std::set<int> result;
   for (const auto &record_map_it : record_map) {
-    result.insert(record_map_it.first);
+    result.insert((int)record_map_it.first);
   }
   return result;
 }

--- a/include/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/Partitioning/CoordinatedPartitionState.hpp
@@ -74,9 +74,9 @@ class CoordinatedPartitionState : public PartitionState<T> {
   int getMachineWithMinWeight() const override;
   int getMachineWithMinWeight(const std::set<int> &partitions) const override;
   std::vector<int> getMachines_load() const override;
-  int getTotalReplicas() const override;
-  int getNumVertices() const override;
-  std::set<int> getVertexIds() const override;
+  size_t getTotalReplicas() const override;
+  size_t getNumVertices() const override;
+  std::set<CXXGraph::id_t> getVertexIds() const override;
 
   void incrementMachineLoadVertices(const int m);
   std::vector<int> getMachines_loadVertices() const;
@@ -219,12 +219,12 @@ std::vector<int> CoordinatedPartitionState<T>::getMachines_load() const {
   return result;
 }
 template <typename T>
-int CoordinatedPartitionState<T>::getTotalReplicas() const {
+size_t CoordinatedPartitionState<T>::getTotalReplicas() const {
   // TODO
   std::lock_guard<std::mutex> lock(*record_map_mutex);
-  int result = 0;
+  size_t result = 0;
   for (const auto &record_map_it : record_map) {
-    int r = record_map_it.second->getReplicas();
+    size_t r = record_map_it.second->getReplicas();
     if (r > 0) {
       result += r;
     } else {
@@ -234,17 +234,17 @@ int CoordinatedPartitionState<T>::getTotalReplicas() const {
   return result;
 }
 template <typename T>
-int CoordinatedPartitionState<T>::getNumVertices() const {
+size_t CoordinatedPartitionState<T>::getNumVertices() const {
   std::lock_guard<std::mutex> lock(*record_map_mutex);
-  return (int)record_map.size();
+  return (size_t)record_map.size();
 }
 template <typename T>
-std::set<int> CoordinatedPartitionState<T>::getVertexIds() const {
+std::set<CXXGraph::id_t> CoordinatedPartitionState<T>::getVertexIds() const {
   std::lock_guard<std::mutex> lock(*record_map_mutex);
   // if (GLOBALS.OUTPUT_FILE_NAME!=null){ out.close(); }
-  std::set<int> result;
+  std::set<CXXGraph::id_t> result;
   for (const auto &record_map_it : record_map) {
-    result.insert((int)record_map_it.first);
+    result.insert((CXXGraph::id_t)record_map_it.first);
   }
   return result;
 }

--- a/include/Partitioning/CoordinatedRecord.hpp
+++ b/include/Partitioning/CoordinatedRecord.hpp
@@ -125,7 +125,7 @@ bool CoordinatedRecord<T>::releaseLock() {
 }
 template <typename T>
 int CoordinatedRecord<T>::getReplicas() const {
-  return partitions.size();
+  return (int)partitions.size();
 }
 template <typename T>
 int CoordinatedRecord<T>::getDegree() const {

--- a/include/Partitioning/EBV.hpp
+++ b/include/Partitioning/EBV.hpp
@@ -75,8 +75,8 @@ void EBV<T>::performStep(shared<const Edge<T>> e, shared<PartitionState<T>> stat
   unsigned long long edgeCardinality = GLOBALS.edgeCardinality;
   unsigned long long vertexCardinality = GLOBALS.vertexCardinality;
   auto nodePair = e->getNodePair();
-  int u = nodePair.first->getId();
-  int v = nodePair.second->getId();
+  CXXGraph::id_t u = nodePair.first->getId();
+  CXXGraph::id_t v = nodePair.second->getId();
 
   std::shared_ptr<Record<T>> u_record = state->getRecord(u);
   std::shared_ptr<Record<T>> v_record = state->getRecord(v);
@@ -147,7 +147,7 @@ void EBV<T>::performStep(shared<const Edge<T>> e, shared<PartitionState<T>> stat
       v_record->addPartition(machine_id);
       cord_state->incrementMachineLoadVertices(machine_id);
     }
-  } catch (const std::bad_cast &e) {
+  } catch (const std::bad_cast &) {
     // use employee's member functions
     // 1-UPDATE RECORDS
     if (!u_record->hasReplicaInPartition(machine_id)) {

--- a/include/Partitioning/EdgeBalancedVertexCut.hpp
+++ b/include/Partitioning/EdgeBalancedVertexCut.hpp
@@ -68,8 +68,8 @@ void EdgeBalancedVertexCut<T>::performStep(shared<const Edge<T>> e,
                                            shared<PartitionState<T>> state) {
   int P = GLOBALS.numberOfPartition;
   auto nodePair = e->getNodePair();
-  int u = nodePair.first->getId();
-  int v = nodePair.second->getId();
+  CXXGraph::id_t u = nodePair.first->getId();
+  CXXGraph::id_t v = nodePair.second->getId();
 
   std::shared_ptr<Record<T>> u_record = state->getRecord(u);
   std::shared_ptr<Record<T>> v_record = state->getRecord(v);
@@ -125,7 +125,7 @@ void EdgeBalancedVertexCut<T>::performStep(shared<const Edge<T>> e,
       v_record->addPartition(machine_id);
       cord_state->incrementMachineLoadVertices(machine_id);
     }
-  } catch (const std::bad_cast &e) {
+  } catch (const std::bad_cast &) {
     // use employee's member functions
     // 1-UPDATE RECORDS
     if (!u_record->hasReplicaInPartition(machine_id)) {

--- a/include/Partitioning/GreedyVertexCut.hpp
+++ b/include/Partitioning/GreedyVertexCut.hpp
@@ -69,8 +69,8 @@ void GreedyVertexCut<T>::performStep(shared<const Edge<T>> e,
                                      shared<PartitionState<T>> state) {
   int P = GLOBALS.numberOfPartition;
   auto nodePair = e->getNodePair();
-  int u = nodePair.first->getId();
-  int v = nodePair.second->getId();
+  CXXGraph::id_t u = nodePair.first->getId();
+  CXXGraph::id_t v = nodePair.second->getId();
 
   std::shared_ptr<Record<T>> u_record = state->getRecord(u);
   std::shared_ptr<Record<T>> v_record = state->getRecord(v);
@@ -208,7 +208,7 @@ void GreedyVertexCut<T>::performStep(shared<const Edge<T>> e,
       v_record->addPartition(machine_id);
       cord_state->incrementMachineLoadVertices(machine_id);
     }
-  } catch (const std::bad_cast &e) {
+  } catch (const std::bad_cast &) {
     // use employee's member functions
     // 1-UPDATE RECORDS
     if (!u_record->hasReplicaInPartition(machine_id)) {

--- a/include/Partitioning/HDRF.hpp
+++ b/include/Partitioning/HDRF.hpp
@@ -71,8 +71,8 @@ void HDRF<T>::performStep(shared<const Edge<T>> e, shared<PartitionState<T>> sta
   double lambda = GLOBALS.param1;
   double epsilon = GLOBALS.param2;
   auto nodePair = e->getNodePair();
-  int u = nodePair.first->getId();
-  int v = nodePair.second->getId();
+  CXXGraph::id_t u = nodePair.first->getId();
+  CXXGraph::id_t v = nodePair.second->getId();
   std::shared_ptr<Record<T>> u_record = state->getRecord(u);
   std::shared_ptr<Record<T>> v_record = state->getRecord(v);
 
@@ -180,7 +180,7 @@ void HDRF<T>::performStep(shared<const Edge<T>> e, shared<PartitionState<T>> sta
       v_record->addPartition(machine_id);
       cord_state->incrementMachineLoadVertices(machine_id);
     }
-  } catch (const std::bad_cast &e) {
+  } catch (const std::bad_cast &) {
     // use employee's member functions
     // 1-UPDATE RECORDS
     if (!u_record->hasReplicaInPartition(machine_id)) {

--- a/include/Partitioning/Partition.hpp
+++ b/include/Partitioning/Partition.hpp
@@ -52,8 +52,8 @@ template <typename T>
 class Partition : public Graph<T> {
  public:
   Partition();
-  Partition(const CXXGraph::id_t partitionId);
-  Partition(const T_EdgeSet<T> &edgeSet);
+  explicit Partition(const CXXGraph::id_t partitionId);
+  explicit Partition(const T_EdgeSet<T> &edgeSet);
   Partition(const CXXGraph::id_t partitionId, const T_EdgeSet<T> &edgeSet);
   ~Partition() = default;
   /**

--- a/include/Partitioning/Partition.hpp
+++ b/include/Partitioning/Partition.hpp
@@ -52,25 +52,25 @@ template <typename T>
 class Partition : public Graph<T> {
  public:
   Partition();
-  Partition(const unsigned int partitionId);
+  Partition(const CXXGraph::id_t partitionId);
   Partition(const T_EdgeSet<T> &edgeSet);
-  Partition(const unsigned int partitionId, const T_EdgeSet<T> &edgeSet);
+  Partition(const CXXGraph::id_t partitionId, const T_EdgeSet<T> &edgeSet);
   ~Partition() = default;
   /**
    * @brief Get the Partition ID
    *
    * @return The ID of the partition
    */
-  unsigned int getPartitionId() const;
+  CXXGraph::id_t getPartitionId() const;
   /**
    * @brief Set the Partition ID
    *
    * @param partitionId the ID to set
    */
-  void setPartitionId(const unsigned int partitionId);
+  void setPartitionId(const CXXGraph::id_t partitionId);
 
  private:
-  unsigned int partitionId = 0;
+  CXXGraph::id_t partitionId = 0;
 };
 
 /**
@@ -177,7 +177,7 @@ Partition<T>::Partition() : Graph<T>() {
 }
 
 template <typename T>
-Partition<T>::Partition(const unsigned int partitionId) : Graph<T>() {
+Partition<T>::Partition(const CXXGraph::id_t partitionId) : Graph<T>() {
   this->partitionId = partitionId;
 }
 
@@ -187,19 +187,19 @@ Partition<T>::Partition(const T_EdgeSet<T> &edgeSet) : Graph<T>(edgeSet) {
 }
 
 template <typename T>
-Partition<T>::Partition(const unsigned int partitionId,
+Partition<T>::Partition(const CXXGraph::id_t partitionId,
                         const T_EdgeSet<T> &edgeSet)
     : Graph<T>(edgeSet) {
   this->partitionId = partitionId;
 }
 
 template <typename T>
-unsigned int Partition<T>::getPartitionId() const {
+CXXGraph::id_t Partition<T>::getPartitionId() const {
   return partitionId;
 }
 
 template <typename T>
-void Partition<T>::setPartitionId(const unsigned int partitionId) {
+void Partition<T>::setPartitionId(const CXXGraph::id_t partitionId) {
   this->partitionId = partitionId;
 }
 

--- a/include/Partitioning/PartitionState.hpp
+++ b/include/Partitioning/PartitionState.hpp
@@ -51,9 +51,9 @@ class PartitionState {
   virtual int getMachineWithMinWeight(
       const std::set<int>& partitions) const = 0;
   virtual std::vector<int> getMachines_load() const = 0;
-  virtual int getTotalReplicas() const = 0;
-  virtual int getNumVertices() const = 0;
-  virtual std::set<int> getVertexIds() const = 0;
+  virtual size_t getTotalReplicas() const = 0;
+  virtual size_t getNumVertices() const = 0;
+  virtual std::set<CXXGraph::id_t> getVertexIds() const = 0;
 };
 }  // namespace Partitioning
 }  // namespace CXXGraph

--- a/include/Partitioning/PartitionState.hpp
+++ b/include/Partitioning/PartitionState.hpp
@@ -39,7 +39,7 @@ namespace Partitioning {
 template <typename T>
 class PartitionState {
  public:
-  virtual shared<Record<T>> getRecord(const int x) = 0;
+  virtual shared<Record<T>> getRecord(CXXGraph::id_t x) = 0;
   virtual int getMachineLoad(const int m) const = 0;
   virtual int getMachineWeight(const int m) const = 0;
   virtual int getMachineLoadVertices(const int m) const = 0;

--- a/include/Partitioning/Partitioner.hpp
+++ b/include/Partitioning/Partitioner.hpp
@@ -158,11 +158,11 @@ CoordinatedPartitionState<T> Partitioner<T>::startCoordinated() {
   std::vector<std::thread> myThreads(processors);
   std::vector<std::shared_ptr<Runnable>> myRunnable(processors);
   std::vector<std::vector<shared<const Edge<T>>>> list_vector(processors);
-  int n = (int)dataset->size();
-  int subSize = n / processors + 1;
+  size_t n = dataset->size();
+  int subSize = (int)n / processors + 1;
   for (int t = 0; t < processors; ++t) {
     int iStart = t * subSize;
-    int iEnd = std::min((t + 1) * subSize, n);
+    int iEnd = std::min((t + 1) * subSize, (int)n);
     if (iEnd >= iStart) {
       list_vector[t] =
           std::vector<shared<const Edge<T>>>(std::next(dataset->begin(), iStart),

--- a/include/Partitioning/Partitioner.hpp
+++ b/include/Partitioning/Partitioner.hpp
@@ -158,7 +158,7 @@ CoordinatedPartitionState<T> Partitioner<T>::startCoordinated() {
   std::vector<std::thread> myThreads(processors);
   std::vector<std::shared_ptr<Runnable>> myRunnable(processors);
   std::vector<std::vector<shared<const Edge<T>>>> list_vector(processors);
-  int n = dataset->size();
+  int n = (int)dataset->size();
   int subSize = n / processors + 1;
   for (int t = 0; t < processors; ++t) {
     int iStart = t * subSize;

--- a/include/Utility/Typedef.hpp
+++ b/include/Utility/Typedef.hpp
@@ -31,6 +31,7 @@
 
 #include "ConstValue.hpp"
 #include "PointerHash.hpp"
+#include "id_t.hpp"
 
 namespace CXXGraph {
 // Smart pointers alias

--- a/include/Utility/Typedef.hpp
+++ b/include/Utility/Typedef.hpp
@@ -78,7 +78,7 @@ enum TarjanAlgorithmTypes {
 
 /// Struct useful for union-find operations
 struct Subset_struct {
-  unsigned long long parent = 0;  // parent of the current set
+  CXXGraph::id_t parent = 0;  // parent of the current set
   unsigned long long rank =
       0;  // rank of the current set, used for balancing the trees
 };

--- a/include/Utility/id_t.hpp
+++ b/include/Utility/id_t.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace CXXGraph {
+#ifdef CXXGRAPH_ID_TYPE
+typedef CXXGRAPH_ID_TYPE id_t;
+#else
+typedef size_t id_t;
+#endif
+}

--- a/include/Utility/id_t.hpp
+++ b/include/Utility/id_t.hpp
@@ -1,9 +1,16 @@
 #pragma once
 
+#include <type_traits>
+
+#define IS_UNSIGNED(T) !(((T)-1) < 0)
+
 namespace CXXGraph {
 #ifdef CXXGRAPH_ID_TYPE
-typedef CXXGRAPH_ID_TYPE id_t;
+    // Throw compiler error if the type is signed
+    static_assert(IS_UNSIGNED(CXXGRAPH_ID_TYPE), "CXXGRAPH_ID_TYPE must be unsigned");
+
+    typedef CXXGRAPH_ID_TYPE id_t;
 #else
-typedef size_t id_t;
+    typedef size_t id_t;
 #endif
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,9 @@ option(CODE_COVERAGE "Enable coverage reporting" OFF)
 option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
 option(gtest_disable_pthreads "Disable uses of pthreads in gtest." ON)
 
+# Force dynamic linking since MSVC now links C runtimes dynamically by default
+set(gtest_force_shared_crt on)
+
 if(CODE_COVERAGE)
 	message( "Code Coverage Enabled" )
 	add_compile_options(

--- a/test/KahnTest.cpp
+++ b/test/KahnTest.cpp
@@ -92,7 +92,7 @@ TEST(KahnTest, correct_example_small) {
   ASSERT_TRUE(res.errorMessage.empty());
   ASSERT_EQ(res.nodesInTopoOrder.size(), graph.getNodeSet().size());
 
-  std::unordered_map<unsigned long, int> topOrderNodeIds;
+  std::unordered_map<CXXGraph::id_t, int> topOrderNodeIds;
   for (int i = 0; i < res.nodesInTopoOrder.size(); ++i) {
     topOrderNodeIds[res.nodesInTopoOrder[i].getId()] = i;
   }
@@ -161,7 +161,7 @@ TEST(KahnTest, correct_example_big) {
   ASSERT_TRUE(res.errorMessage.empty());
   ASSERT_EQ(res.nodesInTopoOrder.size(), graph.getNodeSet().size());
 
-  std::unordered_map<unsigned long, int> topOrderNodeIds;
+  std::unordered_map<CXXGraph::id_t, int> topOrderNodeIds;
   for (int i = 0; i < res.nodesInTopoOrder.size(); ++i) {
     topOrderNodeIds[res.nodesInTopoOrder[i].getId()] = i;
   }

--- a/test/PartitionTest.cpp
+++ b/test/PartitionTest.cpp
@@ -56,7 +56,7 @@ TEST(PartitionTest, test_1) {
   ASSERT_EQ(graph.getEdgeSet().size(), 12);
   auto partitionMap = graph.partitionGraph(
       CXXGraph::Partitioning::PartitionAlgorithm::HDRF_ALG, 4, 1, 0.001);
-  unsigned int totalEdgeInPartition = 0;
+  size_t totalEdgeInPartition = 0;
   for (const auto &elem : partitionMap) {
     totalEdgeInPartition += elem.second->getEdgeSet().size();
   }
@@ -76,7 +76,7 @@ TEST(PartitionTest, test_2) {
   }
   auto partitionMap = graph.partitionGraph(
       CXXGraph::Partitioning::PartitionAlgorithm::HDRF_ALG, 4, 1, 0.001);
-  unsigned int totalEdgeInPartition = 0;
+  size_t totalEdgeInPartition = 0;
   for (const auto &elem : partitionMap) {
     totalEdgeInPartition += elem.second->getEdgeSet().size();
   }
@@ -129,7 +129,7 @@ TEST(PartitionTest, test_3) {
   ASSERT_EQ(graph.getEdgeSet().size(), 12);
   auto partitionMap = graph.partitionGraph(
       CXXGraph::Partitioning::PartitionAlgorithm::EDGEBALANCED_VC_ALG, 4);
-  unsigned int totalEdgeInPartition = 0;
+  size_t totalEdgeInPartition = 0;
   for (const auto &elem : partitionMap) {
     totalEdgeInPartition += elem.second->getEdgeSet().size();
   }
@@ -149,7 +149,7 @@ TEST(PartitionTest, test_4) {
   }
   auto partitionMap = graph.partitionGraph(
       CXXGraph::Partitioning::PartitionAlgorithm::EDGEBALANCED_VC_ALG, 4);
-  unsigned int totalEdgeInPartition = 0;
+  size_t totalEdgeInPartition = 0;
   for (const auto &elem : partitionMap) {
     totalEdgeInPartition += elem.second->getEdgeSet().size();
   }
@@ -202,7 +202,7 @@ TEST(PartitionTest, test_5) {
   ASSERT_EQ(graph.getEdgeSet().size(), 12);
   auto partitionMap = graph.partitionGraph(
       CXXGraph::Partitioning::PartitionAlgorithm::GREEDY_VC_ALG, 4);
-  unsigned int totalEdgeInPartition = 0;
+  size_t totalEdgeInPartition = 0;
   for (const auto &elem : partitionMap) {
     totalEdgeInPartition += elem.second->getEdgeSet().size();
   }
@@ -222,7 +222,7 @@ TEST(PartitionTest, test_6) {
   }
   auto partitionMap = graph.partitionGraph(
       CXXGraph::Partitioning::PartitionAlgorithm::GREEDY_VC_ALG, 4);
-  unsigned int totalEdgeInPartition = 0;
+  size_t totalEdgeInPartition = 0;
   for (const auto &elem : partitionMap) {
     totalEdgeInPartition += elem.second->getEdgeSet().size();
   }
@@ -275,7 +275,7 @@ TEST(PartitionTest, test_7) {
   ASSERT_EQ(graph.getEdgeSet().size(), 12);
   auto partitionMap = graph.partitionGraph(
       CXXGraph::Partitioning::PartitionAlgorithm::EBV_ALG, 4, 1, 1);
-  unsigned int totalEdgeInPartition = 0;
+  size_t totalEdgeInPartition = 0;
   for (const auto &elem : partitionMap) {
     totalEdgeInPartition += elem.second->getEdgeSet().size();
   }
@@ -295,7 +295,7 @@ TEST(PartitionTest, test_8) {
   }
   auto partitionMap = graph.partitionGraph(
       CXXGraph::Partitioning::PartitionAlgorithm::EBV_ALG, 4, 1, 1);
-  unsigned int totalEdgeInPartition = 0;
+  size_t totalEdgeInPartition = 0;
   for (const auto &elem : partitionMap) {
     totalEdgeInPartition += elem.second->getEdgeSet().size();
   }
@@ -316,7 +316,7 @@ TEST(PartitionTest, test_9) {
   auto partitionMap =
       graph.partitionGraph(CXXGraph::Partitioning::PartitionAlgorithm::WB_LIBRA,
                            4, 1.0, 0.0, 0.0, 4);
-  unsigned int totalEdgeInPartition = 0;
+  size_t totalEdgeInPartition = 0;
   for (const auto &elem : partitionMap) {
     totalEdgeInPartition += elem.second->getEdgeSet().size();
     // std::cout << elem.second->getEdgeSet().size() << std::endl;

--- a/test/RWOutputTest.cpp
+++ b/test/RWOutputTest.cpp
@@ -24,7 +24,7 @@ generateRandomNodes(unsigned long numberOfNodes, int MaxValue) {
   std::unordered_map<unsigned long, shared<CXXGraph::Node<int>>> nodes;
   srand(static_cast<unsigned>(time(NULL)));
   int randomNumber;
-  for (auto index = 0; index < numberOfNodes; ++index) {
+  for (unsigned long index = 0; index < numberOfNodes; ++index) {
     // auto index = std::to_string(index);
     randomNumber = (rand() % MaxValue) + 1;
     auto newNode =
@@ -43,7 +43,7 @@ generateRandomEdges(
   int randomNumber1;
   int randomNumber2;
   auto MaxValue = nodes.size();
-  for (auto index = 0; index < numberOfEdges; ++index) {
+  for (unsigned long index = 0; index < numberOfEdges; ++index) {
     randomNumber1 = (rand() % MaxValue);
     randomNumber2 = (rand() % MaxValue);
     auto newEdge = make_shared<CXXGraph::Edge<int>>(
@@ -1118,10 +1118,10 @@ TEST(RWOutputTest, test_27) {
   ASSERT_FALSE(exists_test("test_27_EdgeWeight.tsv.gz"));
   std::ifstream file("test_27.tsv", std::ios::binary);
   file.seekg(0, std::ios::end);
-  int file_size = file.tellg();
+  std::streampos file_size = file.tellg();
   std::ifstream fileCompressed("a.txt", std::ios::binary);
   fileCompressed.seekg(0, std::ios::end);
-  int file_compressed_size = fileCompressed.tellg();
+  std::streampos file_compressed_size = fileCompressed.tellg();
   ASSERT_LE(file_compressed_size, file_size);
 
   remove("test_27.tsv.gz");

--- a/test/TopologicalSortTest.cpp
+++ b/test/TopologicalSortTest.cpp
@@ -96,7 +96,7 @@ TEST(TopologicalSortTest, test_3) {
   ASSERT_EQ(res.nodesInTopoOrder.size(), 8);
 
   // check topological order of nodes
-  std::unordered_map<unsigned long, int> nodeToOrder;
+  std::unordered_map<CXXGraph::id_t, int> nodeToOrder;
   for (int i = 0; i < res.nodesInTopoOrder.size(); ++i) {
     nodeToOrder[res.nodesInTopoOrder[i].getId()] = i;
   }

--- a/test/UnionFindTest.cpp
+++ b/test/UnionFindTest.cpp
@@ -77,7 +77,7 @@ TEST(UnionFindTest, setUnionTest3) {
   CXXGraph::Node<int> node2("2", 2);
   CXXGraph::Node<int> node3("3", 3);
   // union of (node 1 & node3)  should increase node0 rank by 1
-  std::unordered_map<unsigned long long, CXXGraph::Subset> subset;
+  std::unordered_map<CXXGraph::id_t, CXXGraph::Subset> subset;
 
   CXXGraph::Subset set1{0, 0}, set2{0, 0}, set3{0, 0}, set4{1, 0};
   subset = {{0, set1}, {1, set2}, {2, set3}, {3, set4}};

--- a/test/UnionFindTest.cpp
+++ b/test/UnionFindTest.cpp
@@ -33,7 +33,7 @@ TEST(UnionFindTest, setFindTest1) {
   CXXGraph::Graph<int> graph(edgeSet);
 
   // every element is a subset of itself
-  std::unordered_map<unsigned long long, CXXGraph::Subset> subset;
+  std::unordered_map<CXXGraph::id_t, CXXGraph::Subset> subset;
   // {{0, 0}, {1, 0}, {2, 0}, {3, 0}};
   CXXGraph::Subset set1{0, 0}, set2{1, 0}, set3{2, 0}, set4{3, 0};
   subset = {{0, set1}, {1, set2}, {2, set3}, {3, set4}};
@@ -53,7 +53,7 @@ TEST(UnionFindTest, setFindTest2) {
   CXXGraph::Node<int> node3("3", 3);
   // element 2 & 4 are subset of 0
   // element 4 is subset of 1
-  std::unordered_map<unsigned long long, CXXGraph::Subset> subset;
+  std::unordered_map<CXXGraph::id_t, CXXGraph::Subset> subset;
 
   CXXGraph::Subset set1{0, 0}, set2{0, 0}, set3{0, 0}, set4{1, 0};
   subset = {{0, set1}, {1, set2}, {2, set3}, {3, set4}};

--- a/test/Utilities.hpp
+++ b/test/Utilities.hpp
@@ -22,7 +22,7 @@ static std::map<unsigned long, shared<CXXGraph::Node<int>>> generateRandomNodes(
   unsigned int randSeed = (unsigned int)time(NULL);
   rand.seed(randSeed);
 
-  for (auto index = 0; index < numberOfNodes; index++) {
+  for (unsigned long index = 0; index < numberOfNodes; index++) {
     int randomNumber = (distribution(rand) % MaxValue) + 1;
     auto newNode =
         make_shared<CXXGraph::Node<int>>(std::to_string(index), randomNumber);
@@ -43,7 +43,7 @@ static std::map<unsigned long, shared<CXXGraph::Edge<int>>> generateRandomEdges(
   rand.seed(randSeed);
 
   auto MaxValue = nodes.size();
-  for (auto index = 0; index < numberOfEdges; index++) {
+  for (unsigned long index = 0; index < numberOfEdges; index++) {
     int randomNumber1 = (distribution(rand) % MaxValue);
     int randomNumber2 = (distribution(rand) % MaxValue);
     auto newEdge = make_shared<CXXGraph::Edge<int>>(


### PR DESCRIPTION
Link to issue: https://github.com/ZigRazor/CXXGraph/issues/338

This PR fixes the inconsistent `id` issues throughout the library.

I also added explicit casts in many places to squelch compiler warnings coming from MSVC.

@ZigRazor This PR represents an API-breaking change and forces us to do a major release.
