### PR TITLE
close #345 fixed Node<T> move constructor

### DIFF
--- a/include/Node/Node.hpp
+++ b/include/Node/Node.hpp
@@ -66,7 +66,7 @@ Node<T>::Node(const std::string& id, T&& data) noexcept {
   this->userId = id;
   // the userid is set as sha512 hash of the user provided id
   setId(id);
-  std::swap(this->data, data);
+  this->data = std::move(data);
 }
 
 template <typename T>


### PR DESCRIPTION
 used std::move() in Node<T> move constructor

*A good pull request has the following information:*
- fixed #345 by replacing `std::swap` with `std::move`
- all tests passed locally.
```
[----------] Global test environment tear-down
[==========] 246 tests from 33 test suites ran. (357 ms total)
[  PASSED  ] 246 tests.
```

@ZigRazor 
