### PR TITLE
Feature node storage for Graph class

### DIFF
--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -31,7 +31,6 @@
 #include <cstring>
 #include <deque>
 #include <fstream>
-#include <sstream>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -42,6 +41,7 @@
 #include <optional>
 #include <queue>
 #include <set>
+#include <sstream>
 #include <stack>
 #include <string>
 #include <thread>
@@ -119,8 +119,8 @@ class Graph {
                  const std::string &graphName) const;
   int readFromDot(const std::string &workingDir, const std::string &fileName);
   void recreateGraph(
-      std::unordered_map<CXXGraph::id_t,
-                         std::pair<std::string, std::string>> &edgeMap,
+      std::unordered_map<CXXGraph::id_t, std::pair<std::string, std::string>>
+          &edgeMap,
       std::unordered_map<CXXGraph::id_t, bool> &edgeDirectedMap,
       std::unordered_map<std::string, T> &nodeFeatMap,
       std::unordered_map<CXXGraph::id_t, double> &edgeWeightMap);
@@ -338,9 +338,8 @@ class Graph {
    * @return parent node of elem
    * Note: No Thread Safe
    */
-  virtual CXXGraph::id_t setFind(
-      std::unordered_map<CXXGraph::id_t, Subset> *,
-      const CXXGraph::id_t elem) const;
+  virtual CXXGraph::id_t setFind(std::unordered_map<CXXGraph::id_t, Subset> *,
+                                 const CXXGraph::id_t elem) const;
   /**
    * @brief This function finds the subset of given a nodeId
    * Subset is stored in a map where keys are the hash-id of the node & values
@@ -820,8 +819,10 @@ void Graph<T>::addEdge(const Edge<T> *edge) {
       this->nodeSet.insert(edge_shared->getNodePair().first);
       this->nodeSet.insert(edge_shared->getNodePair().second);
 
-      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {edge_shared->getNodePair().second, edge_shared};
-      (*cachedAdjMatrix)[edge_shared->getNodePair().first].push_back(std::move(elem));
+      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {
+          edge_shared->getNodePair().second, edge_shared};
+      (*cachedAdjMatrix)[edge_shared->getNodePair().first].push_back(
+          std::move(elem));
     } else {
       auto edge_shared = make_shared<DirectedEdge<T>>(*edge);
       this->edgeSet.insert(edge_shared);
@@ -830,8 +831,10 @@ void Graph<T>::addEdge(const Edge<T> *edge) {
       this->nodeSet.insert(edge_shared->getNodePair().first);
       this->nodeSet.insert(edge_shared->getNodePair().second);
 
-      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {edge_shared->getNodePair().second, edge_shared};
-      (*cachedAdjMatrix)[edge_shared->getNodePair().first].push_back(std::move(elem));
+      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {
+          edge_shared->getNodePair().second, edge_shared};
+      (*cachedAdjMatrix)[edge_shared->getNodePair().first].push_back(
+          std::move(elem));
     }
   } else {
     if (edge->isWeighted().has_value() && edge->isWeighted().value()) {
@@ -842,10 +845,14 @@ void Graph<T>::addEdge(const Edge<T> *edge) {
       this->nodeSet.insert(edge_shared->getNodePair().first);
       this->nodeSet.insert(edge_shared->getNodePair().second);
 
-      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {edge_shared->getNodePair().second, edge_shared};
-      (*cachedAdjMatrix)[edge_shared->getNodePair().first].push_back(std::move(elem));
-      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem1 = {edge_shared->getNodePair().first, edge_shared};
-      (*cachedAdjMatrix)[edge_shared->getNodePair().second].push_back(std::move(elem1));
+      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {
+          edge_shared->getNodePair().second, edge_shared};
+      (*cachedAdjMatrix)[edge_shared->getNodePair().first].push_back(
+          std::move(elem));
+      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem1 = {
+          edge_shared->getNodePair().first, edge_shared};
+      (*cachedAdjMatrix)[edge_shared->getNodePair().second].push_back(
+          std::move(elem1));
     } else {
       auto edge_shared = make_shared<UndirectedEdge<T>>(*edge);
       this->edgeSet.insert(edge_shared);
@@ -854,10 +861,14 @@ void Graph<T>::addEdge(const Edge<T> *edge) {
       this->nodeSet.insert(edge_shared->getNodePair().first);
       this->nodeSet.insert(edge_shared->getNodePair().second);
 
-      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {edge_shared->getNodePair().second, edge_shared};
-      (*cachedAdjMatrix)[edge_shared->getNodePair().first].push_back(std::move(elem));
-      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem1 = {edge_shared->getNodePair().first, edge_shared};
-      (*cachedAdjMatrix)[edge_shared->getNodePair().second].push_back(std::move(elem1));
+      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {
+          edge_shared->getNodePair().second, edge_shared};
+      (*cachedAdjMatrix)[edge_shared->getNodePair().first].push_back(
+          std::move(elem));
+      std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem1 = {
+          edge_shared->getNodePair().first, edge_shared};
+      (*cachedAdjMatrix)[edge_shared->getNodePair().second].push_back(
+          std::move(elem1));
     }
   }
 }
@@ -871,15 +882,21 @@ void Graph<T>::addEdge(shared<const Edge<T>> edge) {
   this->nodeSet.insert(edge->getNodePair().second);
 
   /* Adding new edge in cached adjacency matrix */
-  if(edge.get()->isDirected().has_value() && edge.get()->isDirected().value()){
-    std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {edge.get()->getNodePair().second, edge};
-    (*cachedAdjMatrix)[edge.get()->getNodePair().first].push_back(std::move(elem));
-  }
-  else{
-    std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {edge.get()->getNodePair().second, edge};
-    (*cachedAdjMatrix)[edge.get()->getNodePair().first].push_back(std::move(elem));
-    std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem1 = {edge.get()->getNodePair().first, edge};
-    (*cachedAdjMatrix)[edge.get()->getNodePair().second].push_back(std::move(elem1));
+  if (edge.get()->isDirected().has_value() &&
+      edge.get()->isDirected().value()) {
+    std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {
+        edge.get()->getNodePair().second, edge};
+    (*cachedAdjMatrix)[edge.get()->getNodePair().first].push_back(
+        std::move(elem));
+  } else {
+    std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {
+        edge.get()->getNodePair().second, edge};
+    (*cachedAdjMatrix)[edge.get()->getNodePair().first].push_back(
+        std::move(elem));
+    std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem1 = {
+        edge.get()->getNodePair().first, edge};
+    (*cachedAdjMatrix)[edge.get()->getNodePair().second].push_back(
+        std::move(elem1));
   }
 }
 
@@ -906,28 +923,36 @@ void Graph<T>::removeEdge(const CXXGraph::id_t edgeId) {
     int delIndex = -1;
     int i = 0;
     /* Removing the edge from the cached adjacency matrix */
-    for(auto elem : (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().first]){
-      if(elem.second.get()->getId() == edgeId){
+    for (auto elem :
+         (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().first]) {
+      if (elem.second.get()->getId() == edgeId) {
         delIndex = i;
         break;
       }
       i++;
     }
-    if(delIndex != -1){
-      (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().first].erase((*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().first].begin()+delIndex);
+    if (delIndex != -1) {
+      (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().first].erase(
+          (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().first]
+              .begin() +
+          delIndex);
     }
-    
+
     delIndex = -1;
     i = 0;
-    for(auto elem : (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().second]){
-      if(elem.second.get()->getId() == edgeId){
+    for (auto elem :
+         (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().second]) {
+      if (elem.second.get()->getId() == edgeId) {
         delIndex = i;
         break;
       }
       i++;
     }
-    if(delIndex != -1){
-      (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().second].erase((*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().second].begin()+delIndex);
+    if (delIndex != -1) {
+      (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().second].erase(
+          (*cachedAdjMatrix)[edgeOpt.value().get()->getNodePair().second]
+              .begin() +
+          delIndex);
     }
   }
 }
@@ -954,19 +979,18 @@ bool Graph<T>::findEdge(shared<const Node<T>> v1, shared<const Node<T>> v2,
                         CXXGraph::id_t &id) const {
   // This could be made faster by looking for the edge hash, assuming we hash
   // based on node data, instead of a unique integer
-  if(cachedAdjMatrix.get() != NULL && cachedAdjMatrix->size() != 0){
+  if (cachedAdjMatrix.get() != NULL && cachedAdjMatrix->size() != 0) {
     /* Searching for the edge using cached adjacency matrix */
 
-    for(auto elem : (*cachedAdjMatrix)[v1]){
-      if(elem.first == v2){
+    for (auto elem : (*cachedAdjMatrix)[v1]) {
+      if (elem.first == v2) {
         id = elem.second.get()->getId();
         return true;
       }
     }
-  }
-  else{
+  } else {
     /* Searching for the edge using edgeset */
-    
+
     for (auto e : this->edgeSet) {
       if ((e->getNodePair().first == v1) && (e->getNodePair().second == v2)) {
         id = e->getId();
@@ -1362,7 +1386,8 @@ int Graph<T>::compressFile(const std::string &inputFile,
   }
 
   unsigned int zippedBytes;
-  zippedBytes = gzwrite(outFileZ, content_ptr, (unsigned int)strlen(content_ptr));
+  zippedBytes =
+      gzwrite(outFileZ, content_ptr, (unsigned int)strlen(content_ptr));
 
   ifs.close();
   gzclose(outFileZ);
@@ -1697,7 +1722,8 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
             } else if (currentDist + dw_edge->getWeight() < dist[elem.first]) {
               dist[elem.first] = currentDist + dw_edge->getWeight();
               pq.push(std::make_pair(dist[elem.first], elem.first));
-              parent[elem.first.get()->getUserId()] = currentNode.get()->getUserId();
+              parent[elem.first.get()->getUserId()] =
+                  currentNode.get()->getUserId();
             }
           } else if (elem.second->isDirected().has_value() &&
                      !elem.second->isDirected().value()) {
@@ -1710,7 +1736,8 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
             } else if (currentDist + udw_edge->getWeight() < dist[elem.first]) {
               dist[elem.first] = currentDist + udw_edge->getWeight();
               pq.push(std::make_pair(dist[elem.first], elem.first));
-              parent[elem.first.get()->getUserId()] = currentNode.get()->getUserId();
+              parent[elem.first.get()->getUserId()] =
+                  currentNode.get()->getUserId();
             }
           } else {
             // ERROR it shouldn't never returned ( does not exist a Node
@@ -1731,12 +1758,12 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
     result.errorMessage = "";
     result.result = dist[*target_node_it];
     std::string id = target.getUserId();
-    while(parent[id] != ""){
+    while (parent[id] != "") {
       result.path.push_back(id);
       id = parent[id];
     }
     result.path.push_back(source.getUserId());
-    std::reverse(result.path.begin(),result.path.end());
+    std::reverse(result.path.begin(), result.path.end());
     return result;
   }
   result.errorMessage = ERR_TARGET_NODE_NOT_REACHABLE;
@@ -3688,10 +3715,9 @@ int Graph<T>::writeToMTXFile(const std::string &workingDir,
   iFile << header;
 
   // Write the line containing the number of nodes and edges
-  const std::string firstLine =
-      std::to_string(nodeSet.size()) + delimitier +
-      std::to_string(nodeSet.size()) + delimitier +
-      std::to_string(getEdgeSet().size()) + '\n';
+  const std::string firstLine = std::to_string(nodeSet.size()) + delimitier +
+                                std::to_string(nodeSet.size()) + delimitier +
+                                std::to_string(getEdgeSet().size()) + '\n';
   iFile << firstLine;
 
   // Construct the edges

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -1136,7 +1136,6 @@ void Graph<T>::writeGraphToStream(std::ostream &oGraph, std::ostream &oNodeFeat,
   }
 
   if (writeNodeFeat) {
-    auto nodeSet = getNodeSet();
     for (const auto &node : nodeSet) {
       oNodeFeat << node->getUserId() << sep << node->getData() << std::endl;
     }
@@ -1491,7 +1490,6 @@ void Graph<T>::setUnion(
 
 template <typename T>
 std::shared_ptr<std::vector<Node<T>>> Graph<T>::eulerianPath() const {
-  const auto nodeSet = Graph<T>::getNodeSet();
   const auto adj = Graph<T>::getAdjMatrix();
 
   std::shared_ptr<std::vector<Node<T>>> eulerPath =
@@ -1627,7 +1625,6 @@ template <typename T>
 const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
                                         const Node<T> &target) const {
   DijkstraResult result;
-  auto nodeSet = Graph<T>::getNodeSet();
 
   auto source_node_it = std::find_if(
       nodeSet.begin(), nodeSet.end(),
@@ -1753,7 +1750,6 @@ const BellmanFordResult Graph<T>::bellmanford(const Node<T> &source,
   result.success = false;
   result.errorMessage = "";
   result.result = INF_DOUBLE;
-  auto nodeSet = Graph<T>::getNodeSet();
   auto source_node_it = std::find_if(
       nodeSet.begin(), nodeSet.end(),
       [&source](auto node) { return node->getUserId() == source.getUserId(); });
@@ -1861,12 +1857,10 @@ const Graph<T> Graph<T>::transitiveReduction() const {
   Graph<T> result(this->edgeSet);
 
   CXXGraph::id_t edgeId = 0;
-  std::unordered_set<shared<const Node<T>>, nodeHash<T>> nodes =
-      this->getNodeSet();
-  for (auto x : nodes) {
-    for (auto y : nodes) {
+  for (auto x : nodeSet) {
+    for (auto y : nodeSet) {
       if (this->findEdge(x, y, edgeId)) {
-        for (auto z : nodes) {
+        for (auto z : nodeSet) {
           if (this->findEdge(y, z, edgeId)) {
             if (this->findEdge(x, z, edgeId)) {
               result.removeEdge(edgeId);
@@ -1888,7 +1882,6 @@ const FWResult Graph<T>::floydWarshall() const {
   std::unordered_map<std::pair<std::string, std::string>, double,
                      CXXGraph::pair_hash>
       pairwise_dist;
-  const auto &nodeSet = Graph<T>::getNodeSet();
   // create a pairwise distance matrix with distance node distances
   // set to inf. Distance of node to itself is set as 0.
   for (const auto &elem1 : nodeSet) {
@@ -1969,7 +1962,6 @@ const MstResult Graph<T>::prim() const {
     result.errorMessage = ERR_NOT_STRONG_CONNECTED;
     return result;
   }
-  auto nodeSet = Graph<T>::getNodeSet();
   auto n = nodeSet.size();
   const auto adj = Graph<T>::getAdjMatrix();
 
@@ -2049,7 +2041,6 @@ const MstResult Graph<T>::boruvka() const {
     result.errorMessage = ERR_DIR_GRAPH;
     return result;
   }
-  const auto nodeSet = Graph<T>::getNodeSet();
   const auto n = nodeSet.size();
 
   // Use std map for storing n subsets.
@@ -2144,7 +2135,6 @@ const MstResult Graph<T>::kruskal() const {
     result.errorMessage = ERR_DIR_GRAPH;
     return result;
   }
-  auto nodeSet = Graph<T>::getNodeSet();
   auto n = nodeSet.size();
 
   // check if all edges are weighted and store the weights
@@ -2194,7 +2184,6 @@ template <typename T>
 BestFirstSearchResult<T> Graph<T>::best_first_search(
     const Node<T> &source, const Node<T> &target) const {
   BestFirstSearchResult<T> result;
-  auto &nodeSet = Graph<T>::getNodeSet();
   using pq_type = std::pair<double, shared<const Node<T>>>;
 
   auto source_node_it = std::find_if(
@@ -2268,7 +2257,6 @@ const std::vector<Node<T>> Graph<T>::breadth_first_search(
     const Node<T> &start) const {
   // vector to keep track of visited nodes
   std::vector<Node<T>> visited;
-  auto &nodeSet = Graph<T>::getNodeSet();
   // check is exist node in the graph
   auto start_node_it = std::find_if(
       nodeSet.begin(), nodeSet.end(),
@@ -2307,7 +2295,6 @@ const std::vector<Node<T>> Graph<T>::concurrency_breadth_first_search(
     const Node<T> &start, size_t num_threads) const {
   std::vector<Node<T>> bfs_result;
   // check is exist node in the graph
-  auto &nodeSet = Graph<T>::getNodeSet();
   auto start_node_it = std::find_if(
       nodeSet.begin(), nodeSet.end(),
       [&start](auto node) { return node->getUserId() == start.getUserId(); });
@@ -2463,7 +2450,6 @@ const std::vector<Node<T>> Graph<T>::depth_first_search(
     const Node<T> &start) const {
   // vector to keep track of visited nodes
   std::vector<Node<T>> visited;
-  auto nodeSet = Graph<T>::getNodeSet();
   // check is exist node in the graph
   auto start_node_it = std::find_if(
       nodeSet.begin(), nodeSet.end(),
@@ -2499,7 +2485,6 @@ bool Graph<T>::isCyclicDirectedGraphDFS() const {
     return false;
   }
   enum nodeStates : uint8_t { not_visited, in_stack, visited };
-  auto nodeSet = Graph<T>::getNodeSet();
   auto adjMatrix = Graph<T>::getAdjMatrix();
 
   /* State of the node.
@@ -2646,7 +2631,6 @@ bool Graph<T>::isCyclicDirectedGraphBFS() const {
     return false;
   }
   const auto adjMatrix = Graph<T>::getAdjMatrix();
-  auto nodeSet = Graph<T>::getNodeSet();
 
   std::unordered_map<CXXGraph::id_t, unsigned int> indegree;
   for (const auto &node : nodeSet) {
@@ -2670,7 +2654,7 @@ bool Graph<T>::isCyclicDirectedGraphBFS() const {
   }
 
   // Vertices that need to be traversed.
-  auto remain = Graph<T>::getNodeSet().size();
+  auto remain = nodeSet.size();
   // While there are safe nodes that we can visit.
   while (!can_be_solved.empty()) {
     auto solved = can_be_solved.front();
@@ -2744,7 +2728,6 @@ bool Graph<T>::isConnectedGraph() const {
   if (!isUndirectedGraph()) {
     return false;
   } else {
-    auto nodeSet = getNodeSet();
     const auto adjMatrix = getAdjMatrix();
     // created visited map
     std::unordered_map<CXXGraph::id_t, bool> visited;
@@ -2784,7 +2767,6 @@ bool Graph<T>::isStronglyConnectedGraph() const {
   if (!isDirectedGraph()) {
     return false;
   } else {
-    auto nodeSet = getNodeSet();
     const auto adjMatrix = getAdjMatrix();
     for (const auto &start_node : nodeSet) {
       // created visited map
@@ -2844,7 +2826,6 @@ const TarjanResult<T> Graph<T>::tarjan(const unsigned int typeMask) const {
   }
 
   const auto &adjMatrix = getAdjMatrix();
-  const auto &nodeSet = getNodeSet();
   std::unordered_map<CXXGraph::id_t, int>
       discoveryTime;  // the timestamp when a node is visited
   std::unordered_map<CXXGraph::id_t, int>
@@ -3003,7 +2984,6 @@ TopoSortResult<T> Graph<T>::topologicalSort() const {
     return result;
   } else {
     const auto &adjMatrix = getAdjMatrix();
-    const auto &nodeSet = getNodeSet();
     std::unordered_map<shared<const Node<T>>, bool, nodeHash<T>> visited;
 
     std::function<void(shared<const Node<T>>)> postorder_helper =
@@ -3048,7 +3028,6 @@ TopoSortResult<T> Graph<T>::kahn() const {
     return result;
   } else {
     const auto adjMatrix = Graph<T>::getAdjMatrix();
-    const auto nodeSet = Graph<T>::getNodeSet();
     result.nodesInTopoOrder.reserve(adjMatrix->size());
 
     std::unordered_map<CXXGraph::id_t, unsigned int> indegree;
@@ -3106,7 +3085,6 @@ SCCResult<T> Graph<T>::kosaraju() const {
     result.errorMessage = ERR_UNDIR_GRAPH;
     return result;
   } else {
-    auto nodeSet = getNodeSet();
     const auto adjMatrix = getAdjMatrix();
     // created visited map
     std::unordered_map<CXXGraph::id_t, bool> visited;
@@ -3199,7 +3177,6 @@ const DialResult Graph<T>::dial(const Node<T> &source, int maxWeight) const {
   result.success = false;
 
   const auto adj = getAdjMatrix();
-  auto nodeSet = getNodeSet();
 
   auto source_node_it = std::find_if(
       nodeSet.begin(), nodeSet.end(),
@@ -3354,7 +3331,6 @@ double Graph<T>::fordFulkersonMaxFlow(const Node<T> &source,
   }
 
   // Constuct iterators for source and target nodes in nodeSet
-  auto nodeSet = getNodeSet();
   auto source_node_ptr = *std::find_if(
       nodeSet.begin(), nodeSet.end(),
       [&source](auto node) { return node->getUserId() == source.getUserId(); });
@@ -3406,7 +3382,6 @@ template <typename T>
 const std::vector<Node<T>> Graph<T>::graph_slicing(const Node<T> &start) const {
   std::vector<Node<T>> result;
 
-  auto nodeSet = Graph<T>::getNodeSet();
   // check if start node in the graph
   auto start_node_it = std::find_if(
       nodeSet.begin(), nodeSet.end(),
@@ -3714,8 +3689,8 @@ int Graph<T>::writeToMTXFile(const std::string &workingDir,
 
   // Write the line containing the number of nodes and edges
   const std::string firstLine =
-      std::to_string(getNodeSet().size()) + delimitier +
-      std::to_string(getNodeSet().size()) + delimitier +
+      std::to_string(nodeSet.size()) + delimitier +
+      std::to_string(nodeSet.size()) + delimitier +
       std::to_string(getEdgeSet().size()) + '\n';
   iFile << firstLine;
 
@@ -3841,7 +3816,7 @@ PartitionMap<T> Graph<T>::partitionGraph(
                                 param3, numberOfThreads);
   auto edgeSet_ptr = make_shared<const T_EdgeSet<T>>(getEdgeSet());
   globals.edgeCardinality = edgeSet_ptr->size();
-  globals.vertexCardinality = this->getNodeSet().size();
+  globals.vertexCardinality = this->nodeSet.size();
   Partitioning::Partitioner<T> partitioner(edgeSet_ptr, globals);
   Partitioning::CoordinatedPartitionState<T> partitionState =
       partitioner.performCoordinatedPartition();

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -963,6 +963,15 @@ void Graph<T>::removeNode(const std::string &nodeUserId) {
   if (nodeOpt.has_value()) {
     nodeSet.erase(nodeSet.find(nodeOpt.value()));
   }
+
+  // Remove the edges containing the node
+  auto edgeset = edgeSet;
+  for (auto edgeIt : edgeset) {
+    if (edgeIt->getNodePair().first->getUserId() == nodeUserId ||
+        edgeIt->getNodePair().second->getUserId() == nodeUserId) {
+      this->removeEdge(edgeIt->getId());
+    }
+  }
 }
 
 template <typename T>

--- a/include/Graph/Graph.hpp
+++ b/include/Graph/Graph.hpp
@@ -867,8 +867,8 @@ void Graph<T>::addEdge(shared<const Edge<T>> edge) {
   this->edgeSet.insert(edge);
 
   // Add the nodes of the edge
-  this->nodeSet.insert(edge_shared->getNodePair().first);
-  this->nodeSet.insert(edge_shared->getNodePair().second);
+  this->nodeSet.insert(edge->getNodePair().first);
+  this->nodeSet.insert(edge->getNodePair().second);
 
   /* Adding new edge in cached adjacency matrix */
   if(edge.get()->isDirected().has_value() && edge.get()->isDirected().value()){

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -704,6 +704,7 @@ TEST(IsolatedNodeGraphTest, Test_AddNode1) {
 
   // Check that the number of nodes in the graph is 4
   ASSERT_EQ(graph.getNodeSet().size(), 4);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 1);
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
 }
 
@@ -726,6 +727,7 @@ TEST(IsolatedNodeGraphTest, Test_AddNode2) {
 
   // Check that the number of nodes in the graph is 4
   ASSERT_EQ(graph.getNodeSet().size(), 4);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 1);
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
 }
 
@@ -752,6 +754,7 @@ TEST(TestRemoveNode, Test_isolatedNode) {
 
   // Check the initial number of edges and nodes
   ASSERT_EQ(graph.getNodeSet().size(), 6);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 3);
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
 
   // We now remove node 5
@@ -759,6 +762,7 @@ TEST(TestRemoveNode, Test_isolatedNode) {
 
   // Check the final number of edges and nodes
   ASSERT_EQ(graph.getNodeSet().size(), 5);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 2);
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
 }
 
@@ -785,6 +789,7 @@ TEST(TestRemoveNode, Test_connectedNode) {
 
   // Check the initial number of edges and nodes
   ASSERT_EQ(graph.getNodeSet().size(), 6);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 3);
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
 
   // We now remove node 2
@@ -792,6 +797,7 @@ TEST(TestRemoveNode, Test_connectedNode) {
 
   // Check the final number of edges and nodes
   ASSERT_EQ(graph.getNodeSet().size(), 5);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 3);
   ASSERT_EQ(graph.getEdgeSet().size(), 1);
 }
 

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -120,7 +120,7 @@ TEST(GraphTest, FindEdge_Test) {
   edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge));
   edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge2));
   CXXGraph::Graph<int> graph(edgeSet);
-  unsigned long edgeId = 0;
+  size_t edgeId = 0;
   ASSERT_TRUE(graph.findEdge(&node1,&node2,edgeId));
   CXXGraph::UndirectedEdge<int> edge3(3, node1, node3);
 

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -821,3 +821,56 @@ TEST(TestGetNode, Test_1) {
   auto node_notfound = graph.getNode("5");
   ASSERT_FALSE(node_notfound.has_value());
 }
+
+TEST(GraphTest, set_data_isolated) {
+  // Create the graph
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedEdge<int> edge1(1, pairNode);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create isolated nodes and add them to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node4));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node5));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node6));
+
+  std::map<std::string, int> initial_values;
+  // Construct map with the initial values of the nodes data
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    initial_values[nodeIt->getUserId()] = nodeIt->getData();
+  }
+  // Change the data contained in the nodes singularly
+  std::map<std::string, int> new_values;
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    int r = std::rand();
+    graph.setNodeData(nodeIt->getUserId(), r);
+    new_values[nodeIt->getUserId()] = r;
+  }
+  // Check the final values of the node data
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    ASSERT_EQ(nodeIt->getData(), new_values[nodeIt->getUserId()]);
+  }
+
+  // Now set the data of all the nodes at once
+  std::map<std::string, int> data_values;
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    int r = std::rand();
+    data_values[nodeIt->getUserId()] = r;
+  }
+  graph.setNodeData(data_values);
+  for (const auto &nodeIt : graph.getNodeSet()) {
+    ASSERT_EQ(nodeIt->getData(), data_values[nodeIt->getUserId()]);
+  }
+}

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -794,3 +794,24 @@ TEST(TestRemoveNode, Test_connectedNode) {
   ASSERT_EQ(graph.getNodeSet().size(), 5);
   ASSERT_EQ(graph.getEdgeSet().size(), 1);
 }
+
+TEST(TestGetNode, Test_1) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  auto node_found = graph.getNode("2");
+  ASSERT_TRUE(node_found.has_value());
+  ASSERT_EQ(node_found.value()->getUserId(), "2");
+
+  auto node_notfound = graph.getNode("5");
+  ASSERT_FALSE(node_notfound.has_value());
+}

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -684,3 +684,25 @@ TEST(ReverseDirectedGraphTest, test_exception) {
   CXXGraph::Graph<int> mixedGraph(mixedEdgeSet);
   ASSERT_THROW(mixedGraph.reverseDirectedGraph(), std::runtime_error);
 }
+
+TEST(IsolatedNodeGraphTest, Test_1) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create an isolated node and add it to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node4));
+
+  // Check that the number of nodes in the graph is 4
+  ASSERT_EQ(graph.getNodeSet().size(), 4);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+}

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -120,7 +120,7 @@ TEST(GraphTest, FindEdge_Test) {
   edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge));
   edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge2));
   CXXGraph::Graph<int> graph(edgeSet);
-  unsigned long long edgeId = 0;
+  unsigned long edgeId = 0;
   ASSERT_TRUE(graph.findEdge(&node1,&node2,edgeId));
   CXXGraph::UndirectedEdge<int> edge3(3, node1, node3);
 

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -685,7 +685,7 @@ TEST(ReverseDirectedGraphTest, test_exception) {
   ASSERT_THROW(mixedGraph.reverseDirectedGraph(), std::runtime_error);
 }
 
-TEST(IsolatedNodeGraphTest, Test_1) {
+TEST(IsolatedNodeGraphTest, Test_AddNode1) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);
   CXXGraph::Node<int> node3("3", 3);
@@ -705,4 +705,92 @@ TEST(IsolatedNodeGraphTest, Test_1) {
   // Check that the number of nodes in the graph is 4
   ASSERT_EQ(graph.getNodeSet().size(), 4);
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
+}
+
+TEST(IsolatedNodeGraphTest, Test_AddNode2) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create an isolated node and add it to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  graph.addNode(&node4);
+
+  // Check that the number of nodes in the graph is 4
+  ASSERT_EQ(graph.getNodeSet().size(), 4);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+}
+
+TEST(TestRemoveNode, Test_isolatedNode) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create isolated nodes and add them to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node4));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node5));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node6));
+
+  // Check the initial number of edges and nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 6);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+
+  // We now remove node 5
+  graph.removeNode("5");
+
+  // Check the final number of edges and nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 5);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+}
+
+TEST(TestRemoveNode, Test_connectedNode) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create isolated nodes and add them to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node4));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node5));
+  graph.addNode(make_shared<CXXGraph::Node<int>>(node6));
+
+  // Check the initial number of edges and nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 6);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+
+  // We now remove node 2
+  graph.removeNode("2");
+
+  // Check the final number of edges and nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 5);
+  ASSERT_EQ(graph.getEdgeSet().size(), 1);
 }


### PR DESCRIPTION
* Add a cached `nodeSet` member for the `Graph` class, so to support graphs with isolated nodes (#341)
* Add nodes to the `nodeSet` every time that an edge is created  or in the `edgeSet` constructor
* Test a graph with isolated nodes, to make sure that we can increase the number of nodes without also increasing the number of edges
Also, unrelated to the main purpose of the PR:
* Fix the sign of an edgeId in `GraphTest`, which was causing the build to fail (#348)