### PR TITLE
Feature in/out Edges convenience functions

### DIFF
--- a/include/CXXGraph/Graph/Graph.hpp
+++ b/include/CXXGraph/Graph/Graph.hpp
@@ -349,7 +349,7 @@ class Graph {
    * @param Pointer to the node
    *
    */
-  virtual const std::unordered_set<shared<const Edge<T>>, nodeHash<T>> outEdges(
+  virtual const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges(
       const Node<T> *node) const;
   /**
    * \brief
@@ -359,7 +359,7 @@ class Graph {
    * @param Shared pointer to the node
    *
    */
-  virtual const std::unordered_set<shared<const Edge<T>>, nodeHash<T>> outEdges(
+  virtual const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges(
       shared<const Node<T>> node) const;
   /**
    * \brief
@@ -369,7 +369,7 @@ class Graph {
    * @param Pointer to the node
    *
    */
-  virtual const std::unordered_set<shared<const Edge<T>>, nodeHash<T>>
+  virtual const std::unordered_set<shared<const Edge<T>>, edgeHash<T>>
   inOutEdges(const Node<T> *node) const;
   /**
    * \brief
@@ -379,7 +379,7 @@ class Graph {
    * @param Shared pointer to the node
    *
    */
-  virtual const std::unordered_set<shared<const Edge<T>>, nodeHash<T>>
+  virtual const std::unordered_set<shared<const Edge<T>>, edgeHash<T>>
   inOutEdges(shared<const Node<T>> node) const;
   /**
    * @brief This function finds the subset of given a nodeId
@@ -1721,7 +1721,7 @@ Graph<T>::inOutNeighbors(shared<const Node<T>> node) const {
 }
 
 template <typename T>
-const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges(
+const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> Graph<T>::outEdges(
     const Node<T> *node) const {
   auto node_shared = make_shared<const Node<T>>(*node);
 
@@ -1729,14 +1729,14 @@ const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges(
 }
 
 template <typename T>
-const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges(
+const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> Graph<T>::outEdges(
     shared<const Node<T>> node) const {
   if (cachedAdjMatrix->find(node) == cachedAdjMatrix->end()) {
-    return std::unordered_set<shared<const Edge<T>>, nodeHash<T>>();
+    return std::unordered_set<shared<const Edge<T>>, edgeHash<T>>();
   }
   auto nodeEdgePairs = cachedAdjMatrix->at(node);
 
-  std::unordered_set<shared<const Node<T>>, nodeHash<T>> outEdges;
+  std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges;
   for (auto pair : nodeEdgePairs) {
     if (pair.second->isDirected().has_value() &&
         pair.second->isDirected().value()) {
@@ -1748,22 +1748,22 @@ const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges(
 }
 
 template <typename T>
-const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> inOutEdges(
-    const Node<T> *node) const {
+const std::unordered_set<shared<const Edge<T>>, edgeHash<T>>
+Graph<T>::inOutEdges(const Node<T> *node) const {
   auto node_shared = make_shared<const Node<T>>(*node);
 
   return outEdges(node_shared);
 }
 
 template <typename T>
-const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> inOutEdges(
-    shared<const Node<T>> node) const {
+const std::unordered_set<shared<const Edge<T>>, edgeHash<T>>
+Graph<T>::inOutEdges(shared<const Node<T>> node) const {
   if (cachedAdjMatrix->find(node) == cachedAdjMatrix->end()) {
-    return std::unordered_set<shared<const Edge<T>>, nodeHash<T>>();
+    return std::unordered_set<shared<const Edge<T>>, edgeHash<T>>();
   }
   auto nodeEdgePairs = cachedAdjMatrix->at(node);
 
-  std::unordered_set<shared<const Node<T>>, nodeHash<T>> outEdges;
+  std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges;
   for (auto pair : nodeEdgePairs) {
     outEdges.insert(pair.second);
   }

--- a/include/CXXGraph/Graph/Graph.hpp
+++ b/include/CXXGraph/Graph/Graph.hpp
@@ -342,6 +342,46 @@ class Graph {
   virtual const std::unordered_set<shared<const Node<T>>, nodeHash<T>>
   inOutNeighbors(shared<const Node<T>> node) const;
   /**
+   * \brief
+   * \brief This function generates a set of Edges going out of a node
+   * in any graph
+   *
+   * @param Pointer to the node
+   *
+   */
+  virtual const std::unordered_set<shared<const Edge<T>>, nodeHash<T>> outEdges(
+      const Node<T> *node) const;
+  /**
+   * \brief
+   * \brief This function generates a set of Edges going out of a node
+   * in any graph
+   *
+   * @param Shared pointer to the node
+   *
+   */
+  virtual const std::unordered_set<shared<const Edge<T>>, nodeHash<T>> outEdges(
+      shared<const Node<T>> node) const;
+  /**
+   * \brief
+   * \brief This function generates a set of Edges coming in or going out of
+   * a node in any graph
+   *
+   * @param Pointer to the node
+   *
+   */
+  virtual const std::unordered_set<shared<const Edge<T>>, nodeHash<T>>
+  inOutEdges(const Node<T> *node) const;
+  /**
+   * \brief
+   * \brief This function generates a set of Edges coming in or going out of
+   * a node in any graph
+   *
+   * @param Shared pointer to the node
+   *
+   */
+  virtual const std::unordered_set<shared<const Edge<T>>, nodeHash<T>>
+  inOutEdges(shared<const Node<T>> node) const;
+  /**
    * @brief This function finds the subset of given a nodeId
    * Subset is stored in a map where keys are the hash-id of the node & values
    * is the subset.
@@ -1091,7 +1131,7 @@ std::unordered_set<shared<Node<T>>, nodeHash<T>> Graph<T>::nodeSet() {
         std::const_pointer_cast<Node<T>>(edgeSetIt->getNodePair().second));
   }
   for (auto &isNodeIt : isolatedNodesSet) {
-	nodeSet.insert(std::const_pointer_cast<Node<T>>(isNodeIt));
+    nodeSet.insert(std::const_pointer_cast<Node<T>>(isNodeIt));
   }
 
   return nodeSet;
@@ -1678,6 +1718,57 @@ Graph<T>::inOutNeighbors(shared<const Node<T>> node) const {
   }
 
   return inOutNeighbors;
+}
+
+template <typename T>
+const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges(
+    const Node<T> *node) const {
+  auto node_shared = make_shared<const Node<T>>(*node);
+
+  return outEdges(node_shared);
+}
+
+template <typename T>
+const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> outEdges(
+    shared<const Node<T>> node) const {
+  if (cachedAdjMatrix->find(node) == cachedAdjMatrix->end()) {
+    return std::unordered_set<shared<const Edge<T>>, nodeHash<T>>();
+  }
+  auto nodeEdgePairs = cachedAdjMatrix->at(node);
+
+  std::unordered_set<shared<const Node<T>>, nodeHash<T>> outEdges;
+  for (auto pair : nodeEdgePairs) {
+    if (pair.second->isDirected().has_value() &&
+        pair.second->isDirected().value()) {
+      outEdges.insert(pair.second);
+    }
+  }
+
+  return outEdges;
+}
+
+template <typename T>
+const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> inOutEdges(
+    const Node<T> *node) const {
+  auto node_shared = make_shared<const Node<T>>(*node);
+
+  return outEdges(node_shared);
+}
+
+template <typename T>
+const std::unordered_set<shared<const Edge<T>>, edgeHash<T>> inOutEdges(
+    shared<const Node<T>> node) const {
+  if (cachedAdjMatrix->find(node) == cachedAdjMatrix->end()) {
+    return std::unordered_set<shared<const Edge<T>>, nodeHash<T>>();
+  }
+  auto nodeEdgePairs = cachedAdjMatrix->at(node);
+
+  std::unordered_set<shared<const Node<T>>, nodeHash<T>> outEdges;
+  for (auto pair : nodeEdgePairs) {
+    outEdges.insert(pair.second);
+  }
+
+  return outEdges;
 }
 
 template <typename T>

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -121,18 +121,18 @@ TEST(GraphTest, FindEdge_Test) {
   edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge2));
   CXXGraph::Graph<int> graph(edgeSet);
   size_t edgeId = 0;
-  ASSERT_TRUE(graph.findEdge(&node1,&node2,edgeId));
+  ASSERT_TRUE(graph.findEdge(&node1, &node2, edgeId));
   CXXGraph::UndirectedEdge<int> edge3(3, node1, node3);
 
   /* adding edge using addEdge() */
 
   graph.addEdge(make_shared<CXXGraph::UndirectedEdge<int>>(edge3));
-  ASSERT_TRUE(graph.findEdge(&node1,&node3,edgeId));
-  ASSERT_TRUE(graph.findEdge(&node3,&node1,edgeId));
+  ASSERT_TRUE(graph.findEdge(&node1, &node3, edgeId));
+  ASSERT_TRUE(graph.findEdge(&node3, &node1, edgeId));
   CXXGraph::DirectedEdge<int> edge4(4, node1, node5);
   graph.addEdge(make_shared<CXXGraph::DirectedEdge<int>>(edge4));
-  ASSERT_TRUE(graph.findEdge(&node1,&node5,edgeId));
-  ASSERT_FALSE(graph.findEdge(&node5,&node1,edgeId));
+  ASSERT_TRUE(graph.findEdge(&node1, &node5, edgeId));
+  ASSERT_FALSE(graph.findEdge(&node5, &node1, edgeId));
 
   /* removing edge using removeEdge() */
 
@@ -141,16 +141,16 @@ TEST(GraphTest, FindEdge_Test) {
   CXXGraph::DirectedWeightedEdge<int> edge6(8, node2, node5, 10);
 
   /* adding edge using addEdge() */
-  
+
   graph.addEdge(&edge5);
   graph.addEdge(&edge6);
-  ASSERT_FALSE(graph.findEdge(&node2,&node3,edgeId));
-  ASSERT_FALSE(graph.findEdge(&node3,&node2,edgeId));
+  ASSERT_FALSE(graph.findEdge(&node2, &node3, edgeId));
+  ASSERT_FALSE(graph.findEdge(&node3, &node2, edgeId));
 
   /* Test for empty graph */
 
   CXXGraph::Graph<int> graph2;
-  ASSERT_FALSE(graph2.findEdge(&node2,&node3,edgeId));
+  ASSERT_FALSE(graph2.findEdge(&node2, &node3, edgeId));
 }
 
 TEST(GraphTest, RawAddEdge_1) {
@@ -268,16 +268,21 @@ TEST(GraphTest, DirectedEdge_hashequality) {
   CXXGraph::DirectedEdge<int> edge11(11, node7, node2);
 
   CXXGraph::T_EdgeSet<int> edges;
-  auto addEdge = [&](CXXGraph::DirectedEdge<int>& edge)
-  {
+  auto addEdge = [&](CXXGraph::DirectedEdge<int> &edge) {
     size_t currSize = edges.size();
-    auto sharedEdge = CXXGraph::make_shared<CXXGraph::DirectedEdge<int>>(edge.getId(), edge.getFrom(), edge.getTo());
+    auto sharedEdge = CXXGraph::make_shared<CXXGraph::DirectedEdge<int>>(
+        edge.getId(), edge.getFrom(), edge.getTo());
     edges.insert(sharedEdge);
-    if ((currSize + 1) != edges.size())
-    {
-      std::cout << "Skipped " << edge.getNodePair().first->getUserId() << " --> " << edge.getNodePair().second->getUserId() << " (hash: " << CXXGraph::edgeHash<int>{}(sharedEdge) << ")" << std::endl;
+    if ((currSize + 1) != edges.size()) {
+      std::cout << "Skipped " << edge.getNodePair().first->getUserId()
+                << " --> " << edge.getNodePair().second->getUserId()
+                << " (hash: " << CXXGraph::edgeHash<int>{}(sharedEdge) << ")"
+                << std::endl;
     } else {
-      std::cout << "Added " << edge.getNodePair().first->getUserId() << " --> " << edge.getNodePair().second->getUserId() << " (hash: " << CXXGraph::edgeHash<int>{}(sharedEdge) << ")" << std::endl;
+      std::cout << "Added " << edge.getNodePair().first->getUserId() << " --> "
+                << edge.getNodePair().second->getUserId()
+                << " (hash: " << CXXGraph::edgeHash<int>{}(sharedEdge) << ")"
+                << std::endl;
     }
   };
 
@@ -438,7 +443,7 @@ TEST(GraphTest, set_data) {
   }
 }
 
-TEST(GraphTest, test_outEdges) {
+TEST(GraphTest, test_outNodes) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);
   CXXGraph::Node<int> node3("3", 3);
@@ -497,7 +502,7 @@ TEST(GraphTest, test_outEdges) {
 }
 
 // Test the overload that takes shared_ptr as input
-TEST(GraphTest, test_outEdges_shared) {
+TEST(GraphTest, test_outNodes_shared) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);
   CXXGraph::Node<int> node3("3", 3);
@@ -547,7 +552,7 @@ TEST(GraphTest, test_outEdges_shared) {
   }
 }
 
-TEST(GraphTest, test_inOutEdges) {
+TEST(GraphTest, test_inOutNodes) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);
   CXXGraph::Node<int> node3("3", 3);
@@ -594,7 +599,7 @@ TEST(GraphTest, test_inOutEdges) {
 }
 
 // Test the overload that takes shared_ptr as input
-TEST(GraphTest, test_inOutEdges_shared) {
+TEST(GraphTest, test_inOutNodes_shared) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);
   CXXGraph::Node<int> node3("3", 3);
@@ -634,6 +639,196 @@ TEST(GraphTest, test_inOutEdges_shared) {
   }
 }
 
+TEST(InOutNodesTest, test_outEdges) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  CXXGraph::Node<int> node7("7", 7);
+  CXXGraph::Node<int> node8("8", 8);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node1, node3);
+  CXXGraph::DirectedEdge<int> edge3(3, node2, node4);
+  CXXGraph::DirectedEdge<int> edge4(4, node2, node5);
+  CXXGraph::DirectedEdge<int> edge5(5, node3, node4);
+  CXXGraph::DirectedEdge<int> edge6(6, node3, node5);
+  CXXGraph::DirectedEdge<int> edge7(7, node4, node6);
+  CXXGraph::DirectedEdge<int> edge8(8, node4, node7);
+  CXXGraph::DirectedEdge<int> edge9(7, node5, node6);
+  CXXGraph::DirectedEdge<int> edge10(8, node5, node7);
+  CXXGraph::DirectedEdge<int> edge11(8, node6, node8);
+  CXXGraph::DirectedEdge<int> edge12(8, node7, node8);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge8));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge9));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge10));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge11));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge12));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  for (auto x : graph.outEdges(&node1)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge1) ||
+                x == make_shared<const CXXGraph::Edge<int>>(edge2));
+  }
+
+  auto node2_shared = make_shared<const CXXGraph::Node<int>>(node2);
+  for (auto x : graph.outEdges(&node2)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge3) ||
+                x == make_shared<const CXXGraph::Edge<int>>(edge4));
+    ASSERT_FALSE(x == make_shared<const CXXGraph::Edge<int>>(edge1));
+  }
+}
+
+TEST(InOutNodesTest, test_outEdges_shared) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  CXXGraph::Node<int> node7("7", 7);
+  CXXGraph::Node<int> node8("8", 8);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node1, node3);
+  CXXGraph::DirectedEdge<int> edge3(3, node2, node4);
+  CXXGraph::DirectedEdge<int> edge4(4, node2, node5);
+  CXXGraph::DirectedEdge<int> edge5(5, node3, node4);
+  CXXGraph::DirectedEdge<int> edge6(6, node3, node5);
+  CXXGraph::DirectedEdge<int> edge7(7, node4, node6);
+  CXXGraph::DirectedEdge<int> edge8(8, node4, node7);
+  CXXGraph::DirectedEdge<int> edge9(7, node5, node6);
+  CXXGraph::DirectedEdge<int> edge10(8, node5, node7);
+  CXXGraph::DirectedEdge<int> edge11(8, node6, node8);
+  CXXGraph::DirectedEdge<int> edge12(8, node7, node8);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge8));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge9));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge10));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge11));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge12));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  auto node1_shared = make_shared<const CXXGraph::Node<int>>(node1);
+  for (auto x : graph.outEdges(node1_shared)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge1) ||
+                x == make_shared<const CXXGraph::Edge<int>>(edge2));
+  }
+
+  auto node2_shared = make_shared<const CXXGraph::Node<int>>(node2);
+  for (auto x : graph.outEdges(node2_shared)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge3) ||
+                x == make_shared<const CXXGraph::Edge<int>>(edge4));
+    ASSERT_FALSE(x == make_shared<const CXXGraph::Edge<int>>(edge1));
+  }
+}
+
+TEST(InOutNodesTest, test_inOutEdges) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  CXXGraph::Node<int> node7("7", 7);
+  CXXGraph::Node<int> node8("8", 8);
+  CXXGraph::UndirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::UndirectedEdge<int> edge2(2, node1, node3);
+  CXXGraph::UndirectedEdge<int> edge3(3, node2, node3);
+  CXXGraph::UndirectedEdge<int> edge4(4, node2, node4);
+  CXXGraph::UndirectedEdge<int> edge5(5, node4, node5);
+  CXXGraph::UndirectedEdge<int> edge6(6, node4, node6);
+  CXXGraph::UndirectedEdge<int> edge7(7, node6, node7);
+  CXXGraph::UndirectedEdge<int> edge8(8, node6, node8);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge8));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  for (auto x : graph.inOutEdges(&node1)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge1) ||
+                x == make_shared<const CXXGraph::Edge<int>>(edge2));
+  }
+
+  for (auto x : graph.inOutEdges(&node6)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge6) ||
+                x == make_shared<const CXXGraph::Edge<int>>(edge7) ||
+				x == make_shared<const CXXGraph::Edge<int>>(edge8));
+  }
+
+  for (auto x : graph.inOutEdges(&node7)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge7));
+  }
+}
+
+TEST(InOutNodesTest, test_inOutEdges_shared) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  CXXGraph::Node<int> node7("7", 7);
+  CXXGraph::Node<int> node8("8", 8);
+  CXXGraph::UndirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::UndirectedEdge<int> edge2(2, node1, node3);
+  CXXGraph::UndirectedEdge<int> edge3(3, node2, node3);
+  CXXGraph::UndirectedEdge<int> edge4(4, node2, node4);
+  CXXGraph::UndirectedEdge<int> edge5(5, node4, node5);
+  CXXGraph::UndirectedEdge<int> edge6(6, node4, node6);
+  CXXGraph::UndirectedEdge<int> edge7(7, node6, node7);
+  CXXGraph::UndirectedEdge<int> edge8(8, node6, node8);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge8));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  auto node1_shared = make_shared<const CXXGraph::Node<int>>(node1);
+  for (auto x : graph.inOutEdges(node1_shared)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge1) ||
+                x == make_shared<const CXXGraph::Edge<int>>(edge2));
+  }
+
+  auto node6_shared = make_shared<const CXXGraph::Node<int>>(node6);
+  for (auto x : graph.inOutEdges(node6_shared)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge6) ||
+                x == make_shared<const CXXGraph::Edge<int>>(edge7) ||
+				x == make_shared<const CXXGraph::Edge<int>>(edge8));
+  }
+
+  auto node7_shared = make_shared<const CXXGraph::Node<int>>(node7);
+  for (auto x : graph.inOutEdges(node7_shared)) {
+    ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge7));
+  }
+}
+
 TEST(ReverseDirectedGraphTest, test_function) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);
@@ -653,11 +848,13 @@ TEST(ReverseDirectedGraphTest, test_function) {
   // Check edges
   auto originalSet = graph.getEdgeSet();
   auto reverseSet = reverseGraph.getEdgeSet();
-  for (auto originalEdge: originalSet) {
+  for (auto originalEdge : originalSet) {
     for (auto reverseEdge : reverseSet) {
       if (originalEdge->getId() == reverseEdge->getId()) {
-        ASSERT_TRUE(originalEdge->getNodePair().first->getUserId() == reverseEdge->getNodePair().second->getUserId() &&
-                    originalEdge->getNodePair().second->getUserId() == reverseEdge->getNodePair().first->getUserId());
+        ASSERT_TRUE(originalEdge->getNodePair().first->getUserId() ==
+                        reverseEdge->getNodePair().second->getUserId() &&
+                    originalEdge->getNodePair().second->getUserId() ==
+                        reverseEdge->getNodePair().first->getUserId());
       }
     }
   }


### PR DESCRIPTION
Add `outEdges` and `inOutEdges` functions, that return sets of edges linked to a node (issue #310).
* `outEdges` returns the `DirectedEdge`s coming out of a node
* `inOutEdges` returns all the edges contaning a node
 