### PR TITLE
Fix construction of weighted Edge in addEdge overload

### DIFF
--- a/include/CXXGraph/Graph/Graph.hpp
+++ b/include/CXXGraph/Graph/Graph.hpp
@@ -861,7 +861,8 @@ template <typename T>
 void Graph<T>::addEdge(const Edge<T> *edge) {
   if (edge->isDirected().has_value() && edge->isDirected().value()) {
     if (edge->isWeighted().has_value() && edge->isWeighted().value()) {
-      auto edge_shared = make_shared<DirectedWeightedEdge<T>>(*edge);
+      auto edge_shared = make_shared<DirectedWeightedEdge<T>>(
+          *dynamic_cast<const DirectedWeightedEdge<T> *>(edge));
       this->edgeSet.insert(edge_shared);
 
       std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {
@@ -879,7 +880,8 @@ void Graph<T>::addEdge(const Edge<T> *edge) {
     }
   } else {
     if (edge->isWeighted().has_value() && edge->isWeighted().value()) {
-      auto edge_shared = make_shared<UndirectedWeightedEdge<T>>(*edge);
+      auto edge_shared = make_shared<UndirectedWeightedEdge<T>>(
+          *dynamic_cast<const UndirectedWeightedEdge<T> *>(edge));
       this->edgeSet.insert(edge_shared);
 
       std::pair<shared<const Node<T>>, shared<const Edge<T>>> elem = {

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -1,4 +1,7 @@
 
+#include <CXXGraph/Edge/DirectedWeightedEdge.hpp>
+#include <CXXGraph/Edge/UndirectedWeightedEdge.hpp>
+#include <CXXGraph/Edge/Weighted.hpp>
 #include <memory>
 
 #include "CXXGraph/CXXGraph.hpp"
@@ -205,6 +208,44 @@ TEST(GraphTest, RawAddEdge_3) {
 
   ASSERT_FALSE(graph.isDirectedGraph());
   ASSERT_FALSE(graph.isUndirectedGraph());
+}
+
+TEST(GraphTest, AddEdgeWeight_raw) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, node1, node2, 3);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node1, node3, 5);
+  CXXGraph::Graph<int> graph;
+
+  graph.addEdge(&edge1);
+  graph.addEdge(&edge2);
+
+  // Check that the edges are weighted
+  ASSERT_TRUE((*graph.getEdge(1))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(2))->isWeighted());
+  // Check the value of the weights
+  ASSERT_EQ(std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))->getWeight(), 3);
+  ASSERT_EQ(std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))->getWeight(), 5);
+}
+
+TEST(GraphTest, AddEdgeWeight_shared) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, node1, node2, 3);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node1, node3, 5);
+  CXXGraph::Graph<int> graph;
+
+  graph.addEdge(make_shared<const CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  graph.addEdge(make_shared<const CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+
+  // Check that the edges are weighted
+  ASSERT_TRUE((*graph.getEdge(1))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(2))->isWeighted());
+  // Check the value of the weights
+  ASSERT_EQ(std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))->getWeight(), 3);
+  ASSERT_EQ(std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))->getWeight(), 5);
 }
 
 TEST(GraphTest, DirectedEdgeCycle_1) {


### PR DESCRIPTION
* Fix the construction of weighted Edges in the raw pointer overload of addEdge (#350)
* Add tests for verifying that the weight is now initialized correctly