### PR TITLE
Implement generic addNodes and addEdges

### DIFF
--- a/include/CXXGraph/Graph/Graph.hpp
+++ b/include/CXXGraph/Graph/Graph.hpp
@@ -65,6 +65,7 @@
 #include "CXXGraph/Utility/PointerHash.hpp"
 #include "CXXGraph/Utility/Reader.hpp"
 #include "CXXGraph/Utility/ThreadSafe.hpp"
+#include "CXXGraph/Utility/TypeTraits.hpp"
 #include "CXXGraph/Utility/Typedef.hpp"
 #include "CXXGraph/Utility/Writer.hpp"
 
@@ -181,6 +182,21 @@ class Graph {
   virtual void addEdge(shared<const Edge<T>> edge);
   /**
    * \brief
+   * @param
+   *
+   */
+  template <typename... Tn>
+  void addEdges();
+  /**
+   * \brief
+   * @param
+   *
+   */
+  template <typename T1, typename... Tn>
+  std::enable_if<is_edge_v<T1> && (is_edge_v<Tn> && ...), void> addEdges(
+      T1 edge, Tn... edges);
+  /**
+   * \brief
    * Function to add a Node to the Graph Node Set
    * Note: No Thread Safe
    *
@@ -197,6 +213,21 @@ class Graph {
    *
    */
   virtual void addNode(shared<const Node<T>> node);
+  /**
+   * \brief
+   * @param
+   *
+   */
+  template <typename... Tn>
+  void addNodes();
+  /**
+   * \brief
+   * @param
+   *
+   */
+  template <typename T1, typename... Tn>
+  std::enable_if<is_node_v<T1> && (is_node_v<Tn> && ...), void> addNodes(
+      T1 node, Tn... nodes);
   /**
    * \brief
    * Function remove an Edge from the Graph Edge Set
@@ -932,6 +963,20 @@ void Graph<T>::addEdge(shared<const Edge<T>> edge) {
 }
 
 template <typename T>
+template <typename... Tn>
+void Graph<T>::addEdges() {
+  return;
+}
+
+template <typename T>
+template <typename T1, typename... Tn>
+std::enable_if<is_edge_v<T1> && (is_edge_v<Tn> && ...), void> Graph<T>::addEdges(
+    T1 edge, Tn... edges) {
+  addEdge(edge);
+  addEdges(edges...);
+}
+
+template <typename T>
 void Graph<T>::addNode(const Node<T> *node) {
   auto node_shared = make_shared<const Node<T>>(*node);
   this->isolatedNodesSet.insert(node_shared);
@@ -940,6 +985,20 @@ void Graph<T>::addNode(const Node<T> *node) {
 template <typename T>
 void Graph<T>::addNode(shared<const Node<T>> node) {
   this->isolatedNodesSet.insert(node);
+}
+
+template <typename T>
+template <typename... Tn>
+void Graph<T>::addNodes() {
+  return;
+}
+
+template <typename T>
+template <typename T1, typename... Tn>
+std::enable_if<is_node_v<T1> && (is_node_v<Tn> && ...), void> Graph<T>::addNodes(
+    T1 node, Tn... nodes) {
+  addNode(node);
+  addNodes(nodes...);
 }
 
 template <typename T>

--- a/include/CXXGraph/Graph/Graph.hpp
+++ b/include/CXXGraph/Graph/Graph.hpp
@@ -182,14 +182,20 @@ class Graph {
   virtual void addEdge(shared<const Edge<T>> edge);
   /**
    * \brief
-   * @param
+   * Function that adds any number of Edges to the Graph Edge set
+   * Note: This is the overload needed to terminate the
+   * recursion
+   *
+   * @param None
    *
    */
   template <typename... Tn>
   void addEdges();
   /**
    * \brief
-   * @param
+   * Function that adds any number of Edges to the Graph Edge set
+   *
+   * @param Raw pointers or shared pointers to the Edges
    *
    */
   template <typename T1, typename... Tn>
@@ -215,14 +221,19 @@ class Graph {
   virtual void addNode(shared<const Node<T>> node);
   /**
    * \brief
-   * @param
+   * Function that adds any number of Nodes to the Graph Node set
+   * Note: This overload is needed to terminate the recursion
+   *
+   * @param None
    *
    */
   template <typename... Tn>
   void addNodes();
   /**
    * \brief
-   * @param
+   * Function that adds any number of Nodes to the Graph Node set
+   *
+   * @param Raw pointers or shared pointers to the Edges
    *
    */
   template <typename T1, typename... Tn>

--- a/include/CXXGraph/Graph/Graph.hpp
+++ b/include/CXXGraph/Graph/Graph.hpp
@@ -199,7 +199,7 @@ class Graph {
    *
    */
   template <typename T1, typename... Tn>
-  std::enable_if<is_edge_v<T1> && (is_edge_v<Tn> && ...), void> addEdges(
+  std::enable_if<is_edge_ptr_v<T1> && (is_edge_ptr_v<Tn> && ...), void> addEdges(
       T1 edge, Tn... edges);
   /**
    * \brief
@@ -237,7 +237,7 @@ class Graph {
    *
    */
   template <typename T1, typename... Tn>
-  std::enable_if<is_node_v<T1> && (is_node_v<Tn> && ...), void> addNodes(
+  std::enable_if<is_node_ptr_v<T1> && (is_node_ptr_v<Tn> && ...), void> addNodes(
       T1 node, Tn... nodes);
   /**
    * \brief
@@ -981,7 +981,7 @@ void Graph<T>::addEdges() {
 
 template <typename T>
 template <typename T1, typename... Tn>
-std::enable_if<is_edge_v<T1> && (is_edge_v<Tn> && ...), void> Graph<T>::addEdges(
+std::enable_if<is_edge_ptr_v<T1> && (is_edge_ptr_v<Tn> && ...), void> Graph<T>::addEdges(
     T1 edge, Tn... edges) {
   addEdge(edge);
   addEdges(edges...);
@@ -1006,7 +1006,7 @@ void Graph<T>::addNodes() {
 
 template <typename T>
 template <typename T1, typename... Tn>
-std::enable_if<is_node_v<T1> && (is_node_v<Tn> && ...), void> Graph<T>::addNodes(
+std::enable_if<is_node_ptr_v<T1> && (is_node_ptr_v<Tn> && ...), void> Graph<T>::addNodes(
     T1 node, Tn... nodes) {
   addNode(node);
   addNodes(nodes...);

--- a/include/CXXGraph/Utility/TypeTraits.hpp
+++ b/include/CXXGraph/Utility/TypeTraits.hpp
@@ -1,0 +1,64 @@
+/***********************************************************/
+/***      ______  ____  ______                 _         ***/
+/***     / ___\ \/ /\ \/ / ___|_ __ __ _ _ __ | |__	     ***/
+/***    | |    \  /  \  / |  _| '__/ _` | '_ \| '_ \	 ***/
+/***    | |___ /  \  /  \ |_| | | | (_| | |_) | | | |    ***/
+/***     \____/_/\_\/_/\_\____|_|  \__,_| .__/|_| |_|    ***/
+/***                                    |_|			     ***/
+/***********************************************************/
+/***     Header-Only C++ Library for Graph			     ***/
+/***	 Representation and Algorithms				     ***/
+/***********************************************************/
+/***     Author: ZigRazor ***/
+/***	 E-Mail: zigrazor@gmail.com 				     ***/
+/***********************************************************/
+/***	 Collaboration: ----------- 				     ***/
+/***********************************************************/
+/***	 License: AGPL v3.0 ***/
+/***********************************************************/
+
+#ifndef __CXXGRAPH_TYPE_TRAITS__
+#define __CXXGRAPH_TYPE_TRAITS__
+
+#pragma once
+
+#include <memory>
+
+#include "CXXGraph/Edge/DirectedEdge.hpp"
+#include "CXXGraph/Edge/DirectedWeightedEdge.hpp"
+#include "CXXGraph/Edge/Edge.hpp"
+#include "CXXGraph/Edge/UndirectedEdge.hpp"
+#include "CXXGraph/Edge/UndirectedWeightedEdge.hpp"
+#include "CXXGraph/Edge/Weighted.hpp"
+#include "CXXGraph/Node/Node.hpp"
+
+namespace CXXGraph {
+
+// define is_node type trait for Nodes, Nodes pointers and shared pointers
+template <typename T>
+struct is_node : std::false_type {};
+
+template <typename T>
+struct is_node<Node<T>> : std::true_type {};
+
+template <typename T>
+struct is_node<const Node<T>*> : std::true_type {};
+
+template <typename T>
+struct is_node<shared<const Node<T>>> : std::true_type {};
+
+// define is_edge type trait for Edges, Edges pointers and shared pointers
+template <typename T>
+struct is_edge : std::false_type {};
+
+template <typename T>
+struct is_edge<Edge<T>> : std::true_type {};
+
+template <typename T>
+struct is_edge<const Edge<T>*> : std::true_type {};
+
+template <typename T>
+struct is_edge<shared<const Edge<T>>> : std::true_type {};
+}  // namespace CXXGraph
+
+#endif

--- a/include/CXXGraph/Utility/TypeTraits.hpp
+++ b/include/CXXGraph/Utility/TypeTraits.hpp
@@ -47,6 +47,9 @@ struct is_node<const Node<T>*> : std::true_type {};
 template <typename T>
 struct is_node<shared<const Node<T>>> : std::true_type {};
 
+template <typename T>
+inline constexpr bool is_node_v = is_node<T>::value;
+
 // define is_edge type trait for Edges, Edges pointers and shared pointers
 template <typename T>
 struct is_edge : std::false_type {};
@@ -59,6 +62,9 @@ struct is_edge<const Edge<T>*> : std::true_type {};
 
 template <typename T>
 struct is_edge<shared<const Edge<T>>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_edge_v = is_edge<T>::value;
 }  // namespace CXXGraph
 
 #endif

--- a/include/CXXGraph/Utility/TypeTraits.hpp
+++ b/include/CXXGraph/Utility/TypeTraits.hpp
@@ -41,30 +41,38 @@ struct is_node : std::false_type {};
 template <typename T>
 struct is_node<Node<T>> : std::true_type {};
 
+// define is_node_ptr type trait for Node pointers and shared pointers
 template <typename T>
-struct is_node<const Node<T>*> : std::true_type {};
+struct is_node_ptr : std::false_type {};
 
 template <typename T>
-struct is_node<shared<const Node<T>>> : std::true_type {};
+struct is_node_ptr<const Node<T>*> : std::true_type {};
 
 template <typename T>
-inline constexpr bool is_node_v = is_node<T>::value;
+struct is_node_ptr<shared<const Node<T>>> : std::true_type {};
 
-// define is_edge type trait for Edges, Edges pointers and shared pointers
+template <typename T>
+inline constexpr bool is_node_ptr_v = is_node<T>::value;
+
+// define is_edge type trait for Edges
 template <typename T>
 struct is_edge : std::false_type {};
 
 template <typename T>
 struct is_edge<Edge<T>> : std::true_type {};
 
+// define is_edge_ptr type trait for Edge pointers and shared pointers
 template <typename T>
-struct is_edge<const Edge<T>*> : std::true_type {};
+struct is_edge_ptr : std::false_type {};
 
 template <typename T>
-struct is_edge<shared<const Edge<T>>> : std::true_type {};
+struct is_edge_ptr<const Edge<T>*> : std::true_type {};
 
 template <typename T>
-inline constexpr bool is_edge_v = is_edge<T>::value;
+struct is_edge_ptr<shared<const Edge<T>>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_edge_ptr_v = is_edge<T>::value;
 }  // namespace CXXGraph
 
 #endif

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -225,8 +225,14 @@ TEST(GraphTest, AddEdgeWeight_raw) {
   ASSERT_TRUE((*graph.getEdge(1))->isWeighted());
   ASSERT_TRUE((*graph.getEdge(2))->isWeighted());
   // Check the value of the weights
-  ASSERT_EQ(std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))->getWeight(), 3);
-  ASSERT_EQ(std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))->getWeight(), 5);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))
+          ->getWeight(),
+      3);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))
+          ->getWeight(),
+      5);
 }
 
 TEST(GraphTest, AddEdgeWeight_shared) {
@@ -238,14 +244,247 @@ TEST(GraphTest, AddEdgeWeight_shared) {
   CXXGraph::Graph<int> graph;
 
   graph.addEdge(make_shared<const CXXGraph::DirectedWeightedEdge<int>>(edge1));
-  graph.addEdge(make_shared<const CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  graph.addEdge(
+      make_shared<const CXXGraph::UndirectedWeightedEdge<int>>(edge2));
 
   // Check that the edges are weighted
   ASSERT_TRUE((*graph.getEdge(1))->isWeighted());
   ASSERT_TRUE((*graph.getEdge(2))->isWeighted());
   // Check the value of the weights
-  ASSERT_EQ(std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))->getWeight(), 3);
-  ASSERT_EQ(std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))->getWeight(), 5);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))
+          ->getWeight(),
+      3);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))
+          ->getWeight(),
+      5);
+}
+
+TEST(GraphTest, AddEdges_1) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node1, node3);
+  CXXGraph::DirectedEdge<int> edge3(3, node2, node3);
+  CXXGraph::Graph<int> graph;
+
+  graph.addEdges(&edge1, &edge2, &edge3);
+
+  // Check the number of edges
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+  // Check the number of nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+}
+
+TEST(GraphTest, AddEdges_1_shared) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node1, node3);
+  CXXGraph::DirectedEdge<int> edge3(3, node2, node3);
+  CXXGraph::Graph<int> graph;
+
+  auto edge1_shared = make_shared<const CXXGraph::DirectedEdge<int>>(edge1);
+  auto edge2_shared = make_shared<const CXXGraph::DirectedEdge<int>>(edge2);
+  auto edge3_shared = make_shared<const CXXGraph::DirectedEdge<int>>(edge3);
+  graph.addEdges(edge1_shared, edge2_shared, edge3_shared);
+
+  // Check the number of edges
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+  // Check the number of nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+}
+
+TEST(GraphTest, AddEdges_2) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::UndirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::UndirectedEdge<int> edge2(2, node1, node3);
+  CXXGraph::UndirectedEdge<int> edge3(3, node2, node3);
+  CXXGraph::Graph<int> graph;
+
+  graph.addEdges(&edge1, &edge2, &edge3);
+
+  // Check the number of edges
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+  // Check the number of nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+}
+
+TEST(GraphTest, AddEdges_2_shared) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::UndirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::UndirectedEdge<int> edge2(2, node1, node3);
+  CXXGraph::UndirectedEdge<int> edge3(3, node2, node3);
+  CXXGraph::Graph<int> graph;
+
+  auto edge1_shared = make_shared<const CXXGraph::UndirectedEdge<int>>(edge1);
+  auto edge2_shared = make_shared<const CXXGraph::UndirectedEdge<int>>(edge2);
+  auto edge3_shared = make_shared<const CXXGraph::UndirectedEdge<int>>(edge3);
+  graph.addEdges(edge1_shared, edge2_shared, edge3_shared);
+
+  // Check the number of edges
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+  // Check the number of nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+}
+
+TEST(GraphTest, AddEdges_3) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, node1, node2, 4);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node1, node3, 5);
+  CXXGraph::DirectedWeightedEdge<int> edge3(3, node2, node3, 6);
+  CXXGraph::Graph<int> graph;
+
+  graph.addEdges(&edge1, &edge2, &edge3);
+
+  // Check the number of edges
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+  // Check the number of nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+
+  // Check that the edges are weighted
+  ASSERT_TRUE((*graph.getEdge(1))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(2))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(3))->isWeighted());
+  // Check the value of the weights
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))
+          ->getWeight(),
+      4);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))
+          ->getWeight(),
+      5);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(3))
+          ->getWeight(),
+      6);
+}
+
+TEST(GraphTest, AddEdges_3_shared) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, node1, node2, 4);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node1, node3, 5);
+  CXXGraph::DirectedWeightedEdge<int> edge3(3, node2, node3, 6);
+  CXXGraph::Graph<int> graph;
+
+  auto edge1_shared =
+      make_shared<const CXXGraph::DirectedWeightedEdge<int>>(edge1);
+  auto edge2_shared =
+      make_shared<const CXXGraph::DirectedWeightedEdge<int>>(edge2);
+  auto edge3_shared =
+      make_shared<const CXXGraph::DirectedWeightedEdge<int>>(edge3);
+  graph.addEdges(edge1_shared, edge2_shared, edge3_shared);
+
+  // Check the number of edges
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+  // Check the number of nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+
+  // Check that the edges are weighted
+  ASSERT_TRUE((*graph.getEdge(1))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(2))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(3))->isWeighted());
+  // Check the value of the weights
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))
+          ->getWeight(),
+      4);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))
+          ->getWeight(),
+      5);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(3))
+          ->getWeight(),
+      6);
+}
+
+TEST(GraphTest, AddEdges_4) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, node1, node2, 4);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node1, node3, 5);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node2, node3, 6);
+  CXXGraph::Graph<int> graph;
+
+  graph.addEdges(&edge1, &edge2, &edge3);
+
+  // Check the number of edges
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+  // Check the number of nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+
+  // Check that the edges are weighted
+  ASSERT_TRUE((*graph.getEdge(1))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(2))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(3))->isWeighted());
+  // Check the value of the weights
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))
+          ->getWeight(),
+      4);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))
+          ->getWeight(),
+      5);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(3))
+          ->getWeight(),
+      6);
+}
+
+TEST(GraphTest, AddEdges_4_shared) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, node1, node2, 4);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node1, node3, 5);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node2, node3, 6);
+  CXXGraph::Graph<int> graph;
+
+  auto edge1_shared =
+      make_shared<const CXXGraph::UndirectedWeightedEdge<int>>(edge1);
+  auto edge2_shared =
+      make_shared<const CXXGraph::UndirectedWeightedEdge<int>>(edge2);
+  auto edge3_shared =
+      make_shared<const CXXGraph::UndirectedWeightedEdge<int>>(edge3);
+  graph.addEdges(edge1_shared, edge2_shared, edge3_shared);
+
+  // Check the number of edges
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+  // Check the number of nodes
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+
+  // Check that the edges are weighted
+  ASSERT_TRUE((*graph.getEdge(1))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(2))->isWeighted());
+  ASSERT_TRUE((*graph.getEdge(3))->isWeighted());
+  // Check the value of the weights
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(1))
+          ->getWeight(),
+      4);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(2))
+          ->getWeight(),
+      5);
+  ASSERT_EQ(
+      std::dynamic_pointer_cast<const CXXGraph::Weighted>(*graph.getEdge(3))
+          ->getWeight(),
+      6);
 }
 
 TEST(GraphTest, DirectedEdgeCycle_1) {
@@ -821,7 +1060,7 @@ TEST(InOutNodesTest, test_inOutEdges) {
   for (auto x : graph.inOutEdges(&node6)) {
     ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge6) ||
                 x == make_shared<const CXXGraph::Edge<int>>(edge7) ||
-				x == make_shared<const CXXGraph::Edge<int>>(edge8));
+                x == make_shared<const CXXGraph::Edge<int>>(edge8));
   }
 
   for (auto x : graph.inOutEdges(&node7)) {
@@ -867,7 +1106,7 @@ TEST(InOutNodesTest, test_inOutEdges_shared) {
   for (auto x : graph.inOutEdges(node6_shared)) {
     ASSERT_TRUE(x == make_shared<const CXXGraph::Edge<int>>(edge6) ||
                 x == make_shared<const CXXGraph::Edge<int>>(edge7) ||
-				x == make_shared<const CXXGraph::Edge<int>>(edge8));
+                x == make_shared<const CXXGraph::Edge<int>>(edge8));
   }
 
   auto node7_shared = make_shared<const CXXGraph::Node<int>>(node7);

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -1220,6 +1220,56 @@ TEST(IsolatedNodeGraphTest, Test_AddNode2) {
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
 }
 
+TEST(IsolatedNodeGraphTest, Test_AddNodes1) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create an isolated node and add it to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  auto node4_shared = make_shared<CXXGraph::Node<int>>(node4);
+  auto node5_shared = make_shared<CXXGraph::Node<int>>(node5);
+  graph.addNodes(node4_shared, node5_shared);
+
+  // Check that the number of nodes in the graph is 4
+  ASSERT_EQ(graph.getNodeSet().size(), 5);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 2);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+}
+
+TEST(IsolatedNodeGraphTest, Test_AddNodes2) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Create an isolated node and add it to the graph
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  graph.addNodes(&node4, &node5);
+
+  // Check that the number of nodes in the graph is 4
+  ASSERT_EQ(graph.getNodeSet().size(), 5);
+  ASSERT_EQ(graph.getIsolatedNodeSet().size(), 2);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+}
+
 TEST(TestRemoveNode, Test_isolatedNode) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);


### PR DESCRIPTION
Write generic `addEdges` and `addNodes` methods taking an arbitrary number of parameters (issue #361).