### PR TITLE
changing output format of Kosaraju algorithm

### DIFF
--- a/include/CXXGraph/Graph/Graph.hpp
+++ b/include/CXXGraph/Graph/Graph.hpp
@@ -3364,36 +3364,39 @@ SCCResult<T> Graph<T>::kosaraju() const {
 
     visited.clear();
 
-    std::function<void(shared<const Node<T>>, std::vector<Node<T>> &)>
+    std::function<void(shared<const Node<T>>, SCCResult<T>, int)>
         dfs_helper1 =
             [this, &rev, &visited, &dfs_helper1](shared<const Node<T>> source,
-                                                 std::vector<Node<T>> &comp) {
+                                                 SCCResult<T> result, int sccLabel) {
               // mark the vertex visited
               visited[source->getId()] = true;
               // Add the current vertex to the strongly connected
               // component
-              comp.push_back(*source);
+              //comp.push_back(*source);
+              result.sccMap[source->getId()] =  sccLabel;
 
               // travel the neighbors
               for (int i = 0; i < rev[source].size(); i++) {
                 shared<const Node<T>> neighbor = rev[source].at(i).first;
                 if (visited[neighbor->getId()] == false) {
                   // make recursive call from neighbor
-                  dfs_helper1(neighbor, comp);
+                  dfs_helper1(neighbor, result, sccLabel);
                 }
               }
             };
 
+    int sccLabel = 0;
     while (st.size() != 0) {
       auto rem = st.top();
       st.pop();
       if (visited[rem->getId()] == false) {
-        std::vector<Node<T>> comp;
-        dfs_helper1(rem, comp);
-        result.stronglyConnectedComps.push_back(comp);
+        //std::vector<Node<T>> comp;
+        dfs_helper1(rem, result, sccLabel);
+        sccLabel++;
+        //result.stronglyConnectedComps.push_back(comp);
       }
     }
-
+    result.noOfComponents =  sccLabel;
     result.success = true;
     return result;
   }

--- a/include/CXXGraph/Utility/Typedef.hpp
+++ b/include/CXXGraph/Utility/Typedef.hpp
@@ -197,7 +197,9 @@ struct SCCResult_struct {
   bool success =
       false;  // TRUE if the function does not return error, FALSE otherwise
   std::string errorMessage = "";  // message of error
-  Components<T> stronglyConnectedComps;
+  int noOfComponents = 0;
+  std::unordered_map<size_t, int> sccMap;
+  //Components<T> stronglyConnectedComps;
 };
 template <typename T>
 using SCCResult = SCCResult_struct<T>;

--- a/test/KosarajuTest.cpp
+++ b/test/KosarajuTest.cpp
@@ -13,22 +13,16 @@ using std::make_shared;
 
 // helper function to compare strongly connected components (SCC) as computed
 // by the algorithm with expected (correct) SCC
-void compareComponents(CXXGraph::Components<int>& comp1,
+void compareComponents(CXXGraph::SCCResult<int> result,
                        CXXGraph::Components<int>& comp2) {
-  ASSERT_EQ(comp1.size(), comp2.size());
+  ASSERT_EQ(result.noOfComponents, comp2.size());
 
-  for (size_t i = 0; i < comp1.size(); ++i) {
-    std::sort(comp1[i].begin(), comp1[i].end());
-    std::sort(comp2[i].begin(), comp2[i].end());
+  for(int i=0;i<comp2.size();i++){
+    int curComp = result.sccMap[comp2[i][0].getId()];
+    for(int j=1;j<comp2[i].size();j++){
+      ASSERT_EQ(result.sccMap[comp2[i][j].getId()], curComp);
+    }
   }
-
-  std::sort(comp1.begin(), comp1.end(),
-            [](auto& c1, auto& c2) { return c1.front() < c2.front(); });
-
-  std::sort(comp2.begin(), comp2.end(),
-            [](auto& c1, auto& c2) { return c1.front() < c2.front(); });
-
-  ASSERT_EQ(comp1, comp2);
 }
 
 // undirected graph
@@ -39,8 +33,8 @@ TEST(KosarajuTest, test_1) {
   CXXGraph::T_EdgeSet<int> edgeSet;
   edgeSet.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge));
   CXXGraph::Graph<int> graph(edgeSet);
-  auto res = graph.kosaraju();
-  ASSERT_EQ(res.stronglyConnectedComps.size(), 0);
+  CXXGraph::SCCResult<int> res = graph.kosaraju();
+  ASSERT_EQ(res.noOfComponents, 0);
   ASSERT_FALSE(res.success);
   ASSERT_EQ(res.errorMessage, CXXGraph::ERR_UNDIR_GRAPH);
 }
@@ -55,11 +49,11 @@ TEST(KosarajuTest, test_2) {
   edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge1));
   edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
   CXXGraph::Graph<int> graph(edgeSet);
-  auto res = graph.kosaraju();
+  CXXGraph::SCCResult<int> res = graph.kosaraju();
   ASSERT_TRUE(res.success);
   ASSERT_EQ(res.errorMessage, "");
-  ASSERT_EQ(res.stronglyConnectedComps.size(), 1);
-  ASSERT_EQ(res.stronglyConnectedComps[0].size(), 2);
+  ASSERT_EQ(res.noOfComponents, 1);
+  //ASSERT_EQ(res.stronglyConnectedComps[0].size(), 2);
 }
 
 // 1 comp, 2 strongly connected comp
@@ -75,12 +69,12 @@ TEST(KosarajuTest, test_3) {
   edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
   edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge3));
   CXXGraph::Graph<int> graph(edgeSet);
-  auto res = graph.kosaraju();
+  CXXGraph::SCCResult<int> res = graph.kosaraju();
   ASSERT_TRUE(res.success);
   ASSERT_EQ(res.errorMessage, "");
 
   CXXGraph::Components<int> expectedComponents = {{node1, node2}, {node3}};
-  compareComponents(res.stronglyConnectedComps, expectedComponents);
+  compareComponents(res, expectedComponents);
 }
 
 // 2 components, 2 strongly connected comps
@@ -99,12 +93,12 @@ TEST(KosarajuTest, test_4) {
   edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge3));
   edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge4));
   CXXGraph::Graph<int> graph(edgeSet);
-  auto res = graph.kosaraju();
+  CXXGraph::SCCResult<int> res = graph.kosaraju();
   ASSERT_TRUE(res.success);
   ASSERT_EQ(res.errorMessage, "");
   CXXGraph::Components<int> expectedComponents = {{node1, node2},
                                                   {node3, node4}};
-  compareComponents(res.stronglyConnectedComps, expectedComponents);
+  compareComponents(res, expectedComponents);
 }
 
 TEST(KosarajuTest, test_5) {
@@ -168,7 +162,7 @@ TEST(KosarajuTest, test_5) {
   edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge21));
 
   CXXGraph::Graph graph(edgeSet);
-  auto res = graph.kosaraju();
+  CXXGraph::SCCResult<int> res = graph.kosaraju();
   ASSERT_TRUE(res.success);
   ASSERT_EQ(res.errorMessage, "");
 
@@ -179,5 +173,5 @@ TEST(KosarajuTest, test_5) {
       {node8, node9},
       {node10, node11, node12, node13}};
 
-  compareComponents(res.stronglyConnectedComps, expectedComponents);
+  compareComponents(res, expectedComponents);
 }


### PR DESCRIPTION
This PR is for #261.

- Added new fields in SCCResult struct for saving the output as a map.
- Modified Kosaraju algorithm to save output in the map.
- Modified tests