### PR TITLE
Adds deterministic version for boruvka and dijkstra algorithm.

### DIFF
--- a/include/CXXGraph/Graph/Algorithm/Boruvka_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Boruvka_impl.hpp
@@ -123,5 +123,104 @@ const MstResult Graph<T>::boruvka() const {
   return result;
 }
 
+template <typename T>
+const MstResult Graph<T>::boruvka_deterministic() const {
+  MstResult result;
+  result.success = false;
+  result.errorMessage = "";
+  result.mstCost = INF_DOUBLE;
+  if (!isUndirectedGraph()) {
+    result.errorMessage = ERR_DIR_GRAPH;
+    return result;
+  }
+  const auto nodeSet = Graph<T>::getNodeSet();
+  const auto n = nodeSet.size();
+
+  // Use std map for storing n subsets.
+  auto subsets = make_shared<std::unordered_map<CXXGraph::id_t, Subset>>();
+
+  // Initially there are n different trees.
+  // Finally there will be one tree that will be MST
+  auto numTrees = n;
+
+  // check if all edges are weighted and store the weights
+  // in a map whose keys are the edge ids and values are the edge weights
+  const auto edgeSet = Graph<T>::getEdgeSet();
+  std::unordered_map<CXXGraph::id_t, double> edgeWeight;
+  for (const auto &edge : edgeSet) {
+    if (edge->isWeighted().has_value() && edge->isWeighted().value())
+      edgeWeight[edge->getId()] =
+          (std::dynamic_pointer_cast<const Weighted>(edge))->getWeight();
+    else {
+      // No Weighted Edge
+      result.errorMessage = ERR_NO_WEIGHTED_EDGE;
+      return result;
+    }
+  }
+
+  for (const auto &node : nodeSet) {
+    Subset set{node->getId(), 0};
+    (*subsets)[node->getId()] = set;
+  }
+
+  result.mstCost = 0;  // we will store the cost here
+  // exit when only 1 tree i.e. mst
+  while (numTrees > 1) {
+    // Everytime initialize cheapest map
+    // It stores index of the cheapest edge of subset.
+    std::unordered_map<CXXGraph::id_t, CXXGraph::id_t> cheapest;
+    for (const auto &node : nodeSet) cheapest[node->getId()] = INT_MAX;
+
+    // Traverse through all edges and update
+    // cheapest of every component
+    for (const auto &edge : edgeSet) {
+      auto elem = edge->getNodePair();
+      auto edgeId = edge->getId();
+      // Find sets of two corners of current edge
+      auto set1 = Graph<T>::setFind(subsets, elem.first->getId());
+      auto set2 = Graph<T>::setFind(subsets, elem.second->getId());
+
+      // If two corners of current edge belong to
+      // same set, ignore current edge
+      if (set1 == set2) continue;
+
+      // Else check if current edge is closer to previous
+      // cheapest edges of set1 and set2
+      if (cheapest[set1] == INT_MAX ||
+                (edgeWeight[cheapest[set1]] > edgeWeight[edgeId]) ||
+                (edgeWeight[cheapest[set1]] == edgeWeight[edgeId] && cheapest[set1] > edgeId)
+          )
+          cheapest[set1] = edgeId;
+
+      if (cheapest[set2] == INT_MAX ||
+                (edgeWeight[cheapest[set2]] > edgeWeight[edgeId]) ||
+                (edgeWeight[cheapest[set2]] == edgeWeight[edgeId] && cheapest[set2] > edgeId)
+          )
+          cheapest[set2] = edgeId;
+    }
+
+    // iterate over all the vertices and add picked
+    // cheapest edges to MST
+    for (const auto &[nodeId, edgeId] : cheapest) {
+      // Check if cheapest for current set exists
+      if (edgeId != INT_MAX) {
+        auto cheapestNode = Graph<T>::getEdge(edgeId).value()->getNodePair();
+        auto set1 = Graph<T>::setFind(subsets, cheapestNode.first->getId());
+        auto set2 = Graph<T>::setFind(subsets, cheapestNode.second->getId());
+        if (set1 == set2) continue;
+        result.mstCost += edgeWeight[edgeId];
+        auto newEdgeMST = std::make_pair(cheapestNode.first->getUserId(),
+                                         cheapestNode.second->getUserId());
+        result.mst.push_back(newEdgeMST);
+        // take union of set1 and set2 and decrease number of trees
+        Graph<T>::setUnion(subsets, set1, set2);
+        numTrees--;
+      }
+    }
+  }
+  result.success = true;
+  return result;
+}
+
 }  // namespace CXXGraph
 #endif  // __CXXGRAPH_BORUVKA_IMPL_H__

--- a/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
@@ -148,5 +148,320 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
   result.errorMessage = ERR_TARGET_NODE_NOT_REACHABLE;
   return result;
 }
+
+template <typename T>
+const DijkstraResult Graph<T>::dijkstra_deterministic(const Node<T>& source,
+                                                      const Node<T>& target) const {
+    DijkstraResult result;
+    auto nodeSet = Graph<T>::getNodeSet();
+
+    auto source_node_it = std::find_if(
+        nodeSet.begin(), nodeSet.end(),
+        [&source](auto node) { return node->getUserId() == source.getUserId(); });
+    if (source_node_it == nodeSet.end()) {
+        // check if source node exist in the graph
+        result.errorMessage = ERR_SOURCE_NODE_NOT_IN_GRAPH;
+        return result;
+    }
+
+    auto target_node_it = std::find_if(
+        nodeSet.begin(), nodeSet.end(),
+        [&target](auto node) { return node->getUserId() == target.getUserId(); });
+    if (target_node_it == nodeSet.end()) {
+        // check if target node exist in the graph
+        result.errorMessage = ERR_TARGET_NODE_NOT_IN_GRAPH;
+        return result;
+    }
+    // n denotes the number of vertices in graph
+    auto n = cachedAdjMatrix->size();
+
+    // setting all the distances initially to INF_DOUBLE
+    std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
+    std::map<std::string, shared<const Node<T>>> userIds;
+
+    for (const auto& node : nodeSet) {
+        dist[node] = INF_DOUBLE;
+        userIds[node->getUserId()] = node;        
+    }
+
+    std::unordered_map<shared<const Node<T>>, size_t, nodeHash<T>> stableIds;
+    size_t index(0);
+    for (const auto& it : userIds)
+        stableIds[it.second] = index++;
+
+    // creating a min heap using priority queue
+    // first element of pair contains the distance
+    // second element of pair contains the vertex
+
+    struct VertexInfo
+    {
+        double distance = 0;
+        size_t sumOfIds = 0;
+        shared<const Node<T>> node;
+    };
+
+    struct VertexInfoGreater
+    {
+        bool operator()(const VertexInfo& a, const VertexInfo& b) const
+        {
+            if (a.distance == b.distance) 
+                return a.sumOfIds > b.sumOfIds;
+            return a.distance > b.distance;
+        };
+    };
+        
+    std::priority_queue<VertexInfo,
+        std::vector<VertexInfo>,
+        VertexInfoGreater>
+        pq;
+
+    // pushing the source vertex 's' with 0 distance in min heap
+    pq.push(VertexInfo{ 0.0, stableIds[*source_node_it], *source_node_it });
+
+    // marking the distance of source as 0
+    dist[*source_node_it] = 0;
+
+    std::unordered_map<std::string, std::string> parent;
+    parent[source.getUserId()] = "";
+
+    while (!pq.empty()) {
+        // second element of pair denotes the node / vertex
+        shared<const Node<T>> currentNode = pq.top().node;
+        // first element of pair denotes the distance
+        double currentDist = pq.top().distance;
+        auto currentNodesSum = pq.top().sumOfIds;
+
+        pq.pop();
+
+        // for all the reachable vertex from the currently exploring vertex
+        // we will try to minimize the distance
+        if (cachedAdjMatrix->find(currentNode) != cachedAdjMatrix->end()) {
+            for (const auto& elem : cachedAdjMatrix->at(currentNode)) {
+                // minimizing distances
+                if (elem.second->isWeighted().has_value() &&
+                    elem.second->isWeighted().value()) {
+                    if (elem.second->isDirected().has_value() &&
+                        elem.second->isDirected().value()) {
+                        shared<const DirectedWeightedEdge<T>> dw_edge =
+                            std::static_pointer_cast<const DirectedWeightedEdge<T>>(
+                                elem.second);
+                        if (dw_edge->getWeight() < 0) {
+                            result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
+                            return result;
+                        }
+                        else if (currentDist + dw_edge->getWeight() < dist[elem.first]) {
+                            dist[elem.first] = currentDist + dw_edge->getWeight();
+                            pq.push(VertexInfo{ dist[elem.first], currentNodesSum + stableIds[elem.first], elem.first });
+                            parent[elem.first.get()->getUserId()] =
+                              currentNode.get()->getUserId();
+                        }
+                    }
+                    else if (elem.second->isDirected().has_value() &&
+                        !elem.second->isDirected().value()) {
+                        shared<const UndirectedWeightedEdge<T>> udw_edge =
+                            std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
+                                elem.second);
+                        if (udw_edge->getWeight() < 0) {
+                            result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
+                            return result;
+                        }
+                        else if (currentDist + udw_edge->getWeight() < dist[elem.first]) {
+                            dist[elem.first] = currentDist + udw_edge->getWeight();
+                            pq.push(VertexInfo{ dist[elem.first], currentNodesSum + stableIds[elem.first], elem.first });
+                            parent[elem.first.get()->getUserId()] = currentNode.get()->getUserId();
+                        }
+                    }
+                    else {
+                        // ERROR it shouldn't never returned ( does not exist a Node
+                        // Weighted and not Directed/Undirected)
+                        result.errorMessage = ERR_NO_DIR_OR_UNDIR_EDGE;
+                        return result;
+                    }
+                }
+                else {
+                    // No Weighted Edge
+                    result.errorMessage = ERR_NO_WEIGHTED_EDGE;
+                    return result;
+                }
+            }
+        }
+    }
+    if (dist[*target_node_it] != INF_DOUBLE) {
+        result.success = true;
+        result.errorMessage = "";
+        result.result = dist[*target_node_it];
+        std::string id = target.getUserId();
+        while (parent[id] != "") {
+            result.path.push_back(id);
+            id = parent[id];
+        }
+        result.path.push_back(source.getUserId());
+        std::reverse(result.path.begin(), result.path.end());
+        return result;
+    }
+    result.errorMessage = ERR_TARGET_NODE_NOT_REACHABLE;
+    return result;
+}
+
+template <typename T>
+const DijkstraResult Graph<T>::dijkstra_deterministic2(const Node<T>& source,
+                                                       const Node<T>& target) const {
+    DijkstraResult result;
+    auto nodeSet = Graph<T>::getNodeSet();
+
+    auto source_node_it = std::find_if(
+        nodeSet.begin(), nodeSet.end(),
+        [&source](auto node) { return node->getUserId() == source.getUserId(); });
+    if (source_node_it == nodeSet.end()) {
+        // check if source node exist in the graph
+        result.errorMessage = ERR_SOURCE_NODE_NOT_IN_GRAPH;
+        return result;
+    }
+
+    auto target_node_it = std::find_if(
+        nodeSet.begin(), nodeSet.end(),
+        [&target](auto node) { return node->getUserId() == target.getUserId(); });
+    if (target_node_it == nodeSet.end()) {
+        // check if target node exist in the graph
+        result.errorMessage = ERR_TARGET_NODE_NOT_IN_GRAPH;
+        return result;
+    }
+    // n denotes the number of vertices in graph
+    auto n = cachedAdjMatrix->size();
+
+    // setting all the distances initially to INF_DOUBLE
+    std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
+    std::map<std::string, shared<const Node<T>>> userIds;
+
+    for (const auto& node : nodeSet) {
+        dist[node] = INF_DOUBLE;
+        userIds[node->getUserId()] = node;
+    }
+
+    std::unordered_map<shared<const Node<T>>, uint64_t, nodeHash<T>> stableIds;
+    size_t index(0);
+    for (const auto& it : userIds)
+        stableIds[it.second] = index++;
+
+    // creating a min heap using priority queue
+    // first element of pair contains the distance
+    // second element of pair contains the vertex
+
+    struct VertexInfo
+    {
+        double distance = 0;
+        std::vector<size_t> pathToVertex;
+        shared<const Node<T>> node;
+    };
+
+    struct VertexInfoGreater
+    {
+        bool operator()(const VertexInfo& a, const VertexInfo& b) const
+        {
+            if (a.distance == b.distance)
+                return std::lexicographical_compare(begin(b.pathToVertex), end(b.pathToVertex), begin(a.pathToVertex), end(a.pathToVertex));
+            return a.distance > b.distance;
+        };
+    };
+
+    auto addNode = [&](std::vector<size_t> v, const shared<const Node<T>> &node)
+    {
+        v.push_back(stableIds[node]);
+        return v;
+    };
+
+    std::priority_queue<VertexInfo,
+        std::vector<VertexInfo>,
+        VertexInfoGreater>
+        pq;
+
+    // pushing the source vertex 's' with 0 distance in min heap
+    pq.push(VertexInfo{ 0.0, addNode({},*source_node_it), *source_node_it });
+
+    // marking the distance of source as 0
+    dist[*source_node_it] = 0;
+
+    std::unordered_map<std::string, std::string> parent;
+    parent[source.getUserId()] = "";
+
+    while (!pq.empty()) {
+        // second element of pair denotes the node / vertex
+        shared<const Node<T>> currentNode = pq.top().node;
+        // first element of pair denotes the distance
+        double currentDist = pq.top().distance;
+        auto currentNodesPath = pq.top().pathToVertex;
+
+        pq.pop();
+
+        // for all the reachable vertex from the currently exploring vertex
+        // we will try to minimize the distance
+        if (cachedAdjMatrix->find(currentNode) != cachedAdjMatrix->end()) {
+            for (const auto& elem : cachedAdjMatrix->at(currentNode)) {
+                // minimizing distances
+                if (elem.second->isWeighted().has_value() &&
+                    elem.second->isWeighted().value()) {
+                    if (elem.second->isDirected().has_value() &&
+                        elem.second->isDirected().value()) {
+                        shared<const DirectedWeightedEdge<T>> dw_edge =
+                            std::static_pointer_cast<const DirectedWeightedEdge<T>>(
+                                elem.second);
+                        if (dw_edge->getWeight() < 0) {
+                            result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
+                            return result;
+                        }
+                        else if (currentDist + dw_edge->getWeight() < dist[elem.first]) {
+                            dist[elem.first] = currentDist + dw_edge->getWeight();
+                            pq.push(VertexInfo{ dist[elem.first], addNode(currentNodesPath,elem.first), elem.first });
+                            parent[elem.first.get()->getUserId()] =
+                              currentNode.get()->getUserId();
+                        }
+                    }
+                    else if (elem.second->isDirected().has_value() &&
+                        !elem.second->isDirected().value()) {
+                        shared<const UndirectedWeightedEdge<T>> udw_edge =
+                            std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
+                                elem.second);
+                        if (udw_edge->getWeight() < 0) {
+                            result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
+                            return result;
+                        }
+                        else if (currentDist + udw_edge->getWeight() < dist[elem.first]) {
+                            dist[elem.first] = currentDist + udw_edge->getWeight();
+                            pq.push(VertexInfo{ dist[elem.first], addNode(currentNodesPath,elem.first), elem.first });
+                            parent[elem.first.get()->getUserId()] = currentNode.get()->getUserId();
+                        }
+                    }
+                    else {
+                        // ERROR it shouldn't never returned ( does not exist a Node
+                        // Weighted and not Directed/Undirected)
+                        result.errorMessage = ERR_NO_DIR_OR_UNDIR_EDGE;
+                        return result;
+                    }
+                }
+                else {
+                    // No Weighted Edge
+                    result.errorMessage = ERR_NO_WEIGHTED_EDGE;
+                    return result;
+                }
+            }
+        }
+    }
+    if (dist[*target_node_it] != INF_DOUBLE) {
+        result.success = true;
+        result.errorMessage = "";
+        result.result = dist[*target_node_it];
+        std::string id = target.getUserId();
+        while (parent[id] != "") {
+            result.path.push_back(id);
+            id = parent[id];
+        }
+        result.path.push_back(source.getUserId());
+        std::reverse(result.path.begin(), result.path.end());
+        return result;
+    }
+    result.errorMessage = ERR_TARGET_NODE_NOT_REACHABLE;
+    return result;
+}
+
 }  // namespace CXXGraph
 #endif  // __CXXGRAPH_DIJKSTRA_IMPL_H__

--- a/include/CXXGraph/Graph/Graph_decl.h
+++ b/include/CXXGraph/Graph/Graph_decl.h
@@ -495,6 +495,10 @@ class Graph {
    */
   virtual const DijkstraResult dijkstra(const Node<T> &source,
                                         const Node<T> &target) const;
+  virtual const DijkstraResult dijkstra_deterministic(const Node<T> &source,
+                                        const Node<T> &target) const;
+  virtual const DijkstraResult dijkstra_deterministic2(const Node<T> &source,
+                                        const Node<T> &target) const;  
   /**
    * @brief This function runs the tarjan algorithm and returns different types
    * of results depending on the input parameter typeMask.
@@ -562,6 +566,7 @@ class Graph {
    * errorMessage: "" if no error ELSE report the encountered error
    */
   virtual const MstResult boruvka() const;
+  virtual const MstResult boruvka_deterministic() const;
   /**
    * @brief Function runs the kruskal algorithm and returns the minimum spanning
    * tree if the graph is undirected. Note: No Thread Safe

--- a/test/BoruvkaTest.cpp
+++ b/test/BoruvkaTest.cpp
@@ -180,3 +180,170 @@ TEST(BoruvkaTest, test_4) {
   ASSERT_FALSE(res.success);
   ASSERT_EQ(res.errorMessage, CXXGraph::ERR_NO_WEIGHTED_EDGE);
 }
+
+// Deterministic version of algorithm:
+
+// example taken from
+// https://www.geeksforgeeks.org/prims-mst-for-adjacency-list-representation-greedy-algo-6/
+TEST(BoruvkaDeterministicTest, test_1) {
+  CXXGraph::Node<int> node0("0", 0);
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  CXXGraph::Node<int> node7("7", 7);
+  CXXGraph::Node<int> node8("8", 8);
+
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, node0, node1, 4);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node0, node7, 8);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node7, 11);
+  CXXGraph::UndirectedWeightedEdge<int> edge4(4, node1, node2, 8);
+  CXXGraph::UndirectedWeightedEdge<int> edge5(5, node7, node8, 7);
+  CXXGraph::UndirectedWeightedEdge<int> edge6(6, node7, node6, 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge7(7, node8, node2, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge8(8, node8, node6, 6);
+  CXXGraph::UndirectedWeightedEdge<int> edge9(9, node2, node5, 4);
+  CXXGraph::UndirectedWeightedEdge<int> edge10(19, node2, node3, 7);
+  CXXGraph::UndirectedWeightedEdge<int> edge11(11, node6, node5, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge12(12, node3, node4, 9);
+  CXXGraph::UndirectedWeightedEdge<int> edge13(13, node3, node5, 14);
+  CXXGraph::UndirectedWeightedEdge<int> edge14(14, node5, node4, 10);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge8));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge9));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge10));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge11));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge12));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge13));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge14));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::MstResult res = graph.boruvka_deterministic();
+
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.mst.size(), graph.getNodeSet().size() - 1);
+  ASSERT_EQ(res.mstCost, 37);
+  ASSERT_EQ(res.errorMessage, "");
+}
+
+// example taken from
+// https://www.gatevidyalay.com/prims-algorithm-prim-algorithm-example/
+TEST(BoruvkaDeterministicTest, test_2) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  CXXGraph::Node<int> node7("7", 7);
+
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, node1, node2, 28);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node1, node6, 10);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node2, node7, 14);
+  CXXGraph::UndirectedWeightedEdge<int> edge4(4, node2, node3, 16);
+  CXXGraph::UndirectedWeightedEdge<int> edge5(5, node6, node5, 25);
+  CXXGraph::UndirectedWeightedEdge<int> edge6(6, node7, node5, 24);
+  CXXGraph::UndirectedWeightedEdge<int> edge7(7, node7, node4, 18);
+  CXXGraph::UndirectedWeightedEdge<int> edge8(8, node5, node4, 22);
+  CXXGraph::UndirectedWeightedEdge<int> edge9(9, node4, node3, 12);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge8));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge9));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::MstResult res = graph.boruvka_deterministic();
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.mst.size(), graph.getNodeSet().size() - 1);
+  ASSERT_EQ(res.mstCost, 99);
+  ASSERT_EQ(res.errorMessage, "");
+}
+
+// example taken from
+// https://www.gatevidyalay.com/prims-algorithm-prim-algorithm-example/
+TEST(BoruvkaDeterministicTest, test_3) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+  CXXGraph::Node<int> node5("5", 5);
+  CXXGraph::Node<int> node6("6", 6);
+  CXXGraph::Node<int> node7("7", 7);
+
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, node1, node2, 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node1, node3, 5);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node2, node5, 7);
+  CXXGraph::UndirectedWeightedEdge<int> edge4(4, node2, node4, 8);
+  CXXGraph::UndirectedWeightedEdge<int> edge5(5, node2, node3, 4);
+  CXXGraph::UndirectedWeightedEdge<int> edge6(6, node3, node4, 6);
+  CXXGraph::UndirectedWeightedEdge<int> edge7(7, node3, node6, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge8(8, node4, node6, 9);
+  CXXGraph::UndirectedWeightedEdge<int> edge9(9, node4, node5, 11);
+  CXXGraph::UndirectedWeightedEdge<int> edge10(10, node5, node7, 10);
+  CXXGraph::UndirectedWeightedEdge<int> edge11(11, node5, node6, 3);
+  CXXGraph::UndirectedWeightedEdge<int> edge12(12, node6, node7, 12);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge8));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge9));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge10));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge11));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge12));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::MstResult res = graph.boruvka_deterministic();
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.mst.size(), graph.getNodeSet().size() - 1);
+  ASSERT_EQ(res.mstCost, 26);
+  ASSERT_EQ(res.errorMessage, "");
+}
+
+// test for directed and no weighted edge errors
+TEST(BoruvkaDeterministicTest, test_4) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, node1, node2, 1);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node2, node3, 1);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge2));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::MstResult res = graph.boruvka_deterministic();
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_DIR_GRAPH);
+
+  CXXGraph::UndirectedEdge<int> edge3(3, node1, node2);
+  CXXGraph::T_EdgeSet<int> edgeSet1;
+  edgeSet1.insert(make_shared<CXXGraph::UndirectedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph1(edgeSet1);
+  res = graph1.boruvka_deterministic();
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_NO_WEIGHTED_EDGE);
+}

--- a/test/DijkstraTest.cpp
+++ b/test/DijkstraTest.cpp
@@ -435,3 +435,855 @@ TEST(DijkstraTest, target_not_connected_test) {
   ASSERT_EQ(res.errorMessage, CXXGraph::ERR_TARGET_NODE_NOT_IN_GRAPH);
   ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
 }
+
+// Deterministic versions of algorithm:
+
+TEST(DijkstraDeterministicTest, correct_example_1) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, pairNode, 1);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node2, node3, 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(node1, node3);
+  std::vector<std::string> expected;
+  expected.push_back("1");
+  expected.push_back("2");
+  expected.push_back("3");
+  int index = 0;
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 2);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministicTest, correct_example_2) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, pairNode, 5);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node2, node3, 4);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(node1, node3);
+  std::vector<std::string> expected;
+  expected.push_back("1");
+  expected.push_back("3");
+  int index = 0;
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 6);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministicTest, correct_example_3) {
+  // Example from
+  // https://www.analyticssteps.com/blogs/dijkstras-algorithm-shortest-path-algorithm
+  CXXGraph::Node<int> nodeA("A", 1);
+  CXXGraph::Node<int> nodeB("B", 1);
+  CXXGraph::Node<int> nodeC("C", 1);
+  CXXGraph::Node<int> nodeD("D", 1);
+  CXXGraph::Node<int> nodeE("E", 1);
+
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, nodeA, nodeB, 3);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, nodeA, nodeC, 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, nodeB, nodeC, 7);
+  CXXGraph::UndirectedWeightedEdge<int> edge4(4, nodeC, nodeD, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge5(5, nodeB, nodeE, 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge6(6, nodeB, nodeD, 5);
+  CXXGraph::UndirectedWeightedEdge<int> edge7(7, nodeD, nodeE, 7);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge7));
+
+  std::vector<std::string> expected;
+  expected.push_back("C");
+  expected.push_back("A");
+  expected.push_back("B");
+  expected.push_back("E");
+  int index = 0;
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(nodeC, nodeE);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 5);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("C");
+  expected.push_back("A");
+  index = 0;
+  res = graph.dijkstra_deterministic(nodeC, nodeA);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 1);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("C");
+  expected.push_back("A");
+  expected.push_back("B");
+  index = 0;
+  res = graph.dijkstra_deterministic(nodeC, nodeB);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 4);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("C");
+  expected.push_back("D");
+  index = 0;
+  res = graph.dijkstra_deterministic(nodeC, nodeD);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 2);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministicTest, correct_example_4) {
+  // Example from
+  // https://www.freecodecamp.org/news/dijkstras-shortest-path-algorithm-visual-introduction/
+  CXXGraph::Node<int> node0("0", 1);
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::Node<int> node4("4", 1);
+  CXXGraph::Node<int> node5("5", 1);
+  CXXGraph::Node<int> node6("6", 1);
+
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, node0, node1, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node0, node2, 6);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 5);
+  CXXGraph::UndirectedWeightedEdge<int> edge4(4, node2, node3, 8);
+  CXXGraph::UndirectedWeightedEdge<int> edge5(5, node3, node5, 15);
+  CXXGraph::UndirectedWeightedEdge<int> edge6(6, node3, node4, 10);
+  CXXGraph::UndirectedWeightedEdge<int> edge7(7, node4, node5, 6);
+  CXXGraph::UndirectedWeightedEdge<int> edge8(8, node4, node6, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge9(9, node5, node6, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge8));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge9));
+
+  std::vector<std::string> expected;
+  expected.push_back("0");
+  expected.push_back("1");
+  int index = 0;
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(node0, node1);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 2);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("2");
+  index = 0;
+
+  res = graph.dijkstra_deterministic(node0, node2);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 6);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("1");
+  expected.push_back("3");
+  index = 0;
+  res = graph.dijkstra_deterministic(node0, node3);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 7);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("1");
+  expected.push_back("3");
+  expected.push_back("4");
+  index = 0;
+  res = graph.dijkstra_deterministic(node0, node4);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 17);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("1");
+  expected.push_back("3");
+  expected.push_back("5");
+  index = 0;
+  res = graph.dijkstra_deterministic(node0, node5);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 22);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("1");
+  expected.push_back("3");
+  expected.push_back("4");
+  expected.push_back("6");
+  index = 0;
+  res = graph.dijkstra_deterministic(node0, node6);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 19);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministicTest, correct_example_5) {
+  // Example from https://es.wikipedia.org/wiki/Algoritmo_de_Dijkstra
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::Node<int> node4("4", 1);
+  CXXGraph::Node<int> node5("5", 1);
+  CXXGraph::Node<int> node6("6", 1);
+
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, node1, node2, 7);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node1, node3, 9);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node6, 14);
+  CXXGraph::UndirectedWeightedEdge<int> edge4(4, node2, node4, 15);
+  CXXGraph::UndirectedWeightedEdge<int> edge5(5, node2, node3, 10);
+  CXXGraph::UndirectedWeightedEdge<int> edge6(6, node3, node4, 11);
+  CXXGraph::UndirectedWeightedEdge<int> edge7(7, node3, node6, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge8(8, node4, node5, 6);
+  CXXGraph::UndirectedWeightedEdge<int> edge9(9, node6, node5, 9);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge8));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge9));
+
+  std::vector<std::string> expected;
+  int index = 0;
+  expected.push_back("1");
+  expected.push_back("3");
+  expected.push_back("6");
+  expected.push_back("5");
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(node1, node5);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 20);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministicTest, non_weigthed_node_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, pairNode, 5);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(node1, node3);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_NO_WEIGHTED_EDGE);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}
+
+TEST(DijkstraDeterministicTest, negative_weigthed_node_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, pairNode, -5);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node2, node3, 5);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(node1, node3);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_NEGATIVE_WEIGHTED_EDGE);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}
+
+TEST(DijkstraDeterministicTest, unreachable_node_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(node1, node2);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_TARGET_NODE_NOT_REACHABLE);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}
+
+TEST(DijkstraDeterministicTest, source_not_connected_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(node4, node2);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_SOURCE_NODE_NOT_IN_GRAPH);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}
+
+TEST(DijkstraDeterministicTest, target_not_connected_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic(node1, node4);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_TARGET_NODE_NOT_IN_GRAPH);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}
+
+
+
+TEST(DijkstraDeterministic2Test, correct_example_1) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, pairNode, 1);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node2, node3, 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(node1, node3);
+  std::vector<std::string> expected;
+  expected.push_back("1");
+  expected.push_back("2");
+  expected.push_back("3");
+  int index = 0;
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 2);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministic2Test, correct_example_2) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, pairNode, 5);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node2, node3, 4);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(node1, node3);
+  std::vector<std::string> expected;
+  expected.push_back("1");
+  expected.push_back("3");
+  int index = 0;
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 6);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministic2Test, correct_example_3) {
+  // Example from
+  // https://www.analyticssteps.com/blogs/dijkstras-algorithm-shortest-path-algorithm
+  CXXGraph::Node<int> nodeA("A", 1);
+  CXXGraph::Node<int> nodeB("B", 1);
+  CXXGraph::Node<int> nodeC("C", 1);
+  CXXGraph::Node<int> nodeD("D", 1);
+  CXXGraph::Node<int> nodeE("E", 1);
+
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, nodeA, nodeB, 3);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, nodeA, nodeC, 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, nodeB, nodeC, 7);
+  CXXGraph::UndirectedWeightedEdge<int> edge4(4, nodeC, nodeD, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge5(5, nodeB, nodeE, 1);
+  CXXGraph::UndirectedWeightedEdge<int> edge6(6, nodeB, nodeD, 5);
+  CXXGraph::UndirectedWeightedEdge<int> edge7(7, nodeD, nodeE, 7);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge7));
+
+  std::vector<std::string> expected;
+  expected.push_back("C");
+  expected.push_back("A");
+  expected.push_back("B");
+  expected.push_back("E");
+  int index = 0;
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(nodeC, nodeE);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 5);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("C");
+  expected.push_back("A");
+  index = 0;
+  res = graph.dijkstra_deterministic2(nodeC, nodeA);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 1);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("C");
+  expected.push_back("A");
+  expected.push_back("B");
+  index = 0;
+  res = graph.dijkstra_deterministic2(nodeC, nodeB);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 4);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("C");
+  expected.push_back("D");
+  index = 0;
+  res = graph.dijkstra_deterministic2(nodeC, nodeD);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 2);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministic2Test, correct_example_4) {
+  // Example from
+  // https://www.freecodecamp.org/news/dijkstras-shortest-path-algorithm-visual-introduction/
+  CXXGraph::Node<int> node0("0", 1);
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::Node<int> node4("4", 1);
+  CXXGraph::Node<int> node5("5", 1);
+  CXXGraph::Node<int> node6("6", 1);
+
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, node0, node1, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node0, node2, 6);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 5);
+  CXXGraph::UndirectedWeightedEdge<int> edge4(4, node2, node3, 8);
+  CXXGraph::UndirectedWeightedEdge<int> edge5(5, node3, node5, 15);
+  CXXGraph::UndirectedWeightedEdge<int> edge6(6, node3, node4, 10);
+  CXXGraph::UndirectedWeightedEdge<int> edge7(7, node4, node5, 6);
+  CXXGraph::UndirectedWeightedEdge<int> edge8(8, node4, node6, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge9(9, node5, node6, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge8));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge9));
+
+  std::vector<std::string> expected;
+  expected.push_back("0");
+  expected.push_back("1");
+  int index = 0;
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(node0, node1);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 2);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("2");
+  index = 0;
+
+  res = graph.dijkstra_deterministic2(node0, node2);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 6);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("1");
+  expected.push_back("3");
+  index = 0;
+  res = graph.dijkstra_deterministic2(node0, node3);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 7);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("1");
+  expected.push_back("3");
+  expected.push_back("4");
+  index = 0;
+  res = graph.dijkstra_deterministic2(node0, node4);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 17);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("1");
+  expected.push_back("3");
+  expected.push_back("5");
+  index = 0;
+  res = graph.dijkstra_deterministic2(node0, node5);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 22);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+  expected.clear();
+  expected.push_back("0");
+  expected.push_back("1");
+  expected.push_back("3");
+  expected.push_back("4");
+  expected.push_back("6");
+  index = 0;
+  res = graph.dijkstra_deterministic2(node0, node6);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 19);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministic2Test, correct_example_5) {
+  // Example from https://es.wikipedia.org/wiki/Algoritmo_de_Dijkstra
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+  CXXGraph::Node<int> node4("4", 1);
+  CXXGraph::Node<int> node5("5", 1);
+  CXXGraph::Node<int> node6("6", 1);
+
+  CXXGraph::UndirectedWeightedEdge<int> edge1(1, node1, node2, 7);
+  CXXGraph::UndirectedWeightedEdge<int> edge2(2, node1, node3, 9);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node6, 14);
+  CXXGraph::UndirectedWeightedEdge<int> edge4(4, node2, node4, 15);
+  CXXGraph::UndirectedWeightedEdge<int> edge5(5, node2, node3, 10);
+  CXXGraph::UndirectedWeightedEdge<int> edge6(6, node3, node4, 11);
+  CXXGraph::UndirectedWeightedEdge<int> edge7(7, node3, node6, 2);
+  CXXGraph::UndirectedWeightedEdge<int> edge8(8, node4, node5, 6);
+  CXXGraph::UndirectedWeightedEdge<int> edge9(9, node6, node5, 9);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge4));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge5));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge6));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge7));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge8));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge9));
+
+  std::vector<std::string> expected;
+  int index = 0;
+  expected.push_back("1");
+  expected.push_back("3");
+  expected.push_back("6");
+  expected.push_back("5");
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(node1, node5);
+  ASSERT_TRUE(res.success);
+  ASSERT_EQ(res.errorMessage, "");
+  ASSERT_EQ(res.result, 20);
+  ASSERT_EQ(res.path.size(), expected.size());
+  for (auto elem : res.path) {
+    ASSERT_EQ(elem, expected[index]);
+    index++;
+  }
+}
+
+TEST(DijkstraDeterministic2Test, non_weigthed_node_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, pairNode, 5);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(node1, node3);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_NO_WEIGHTED_EDGE);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}
+
+TEST(DijkstraDeterministic2Test, negative_weigthed_node_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  std::pair<const CXXGraph::Node<int> *, const CXXGraph::Node<int> *> pairNode(
+      &node1, &node2);
+  CXXGraph::DirectedWeightedEdge<int> edge1(1, pairNode, -5);
+  CXXGraph::DirectedWeightedEdge<int> edge2(2, node2, node3, 5);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::DirectedWeightedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(node1, node3);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_NEGATIVE_WEIGHTED_EDGE);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}
+
+TEST(DijkstraDeterministic2Test, unreachable_node_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(node1, node2);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_TARGET_NODE_NOT_REACHABLE);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}
+
+TEST(DijkstraDeterministic2Test, source_not_connected_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(node4, node2);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_SOURCE_NODE_NOT_IN_GRAPH);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}
+
+TEST(DijkstraDeterministic2Test, target_not_connected_test) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::Node<int> node4("4", 4);
+
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node3);
+  CXXGraph::UndirectedWeightedEdge<int> edge3(3, node1, node3, 6);
+
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  edgeSet.insert(make_shared<CXXGraph::DirectedEdge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge3));
+
+  CXXGraph::Graph<int> graph(edgeSet);
+  CXXGraph::DijkstraResult res = graph.dijkstra_deterministic2(node1, node4);
+  ASSERT_FALSE(res.success);
+  ASSERT_EQ(res.errorMessage, CXXGraph::ERR_TARGET_NODE_NOT_IN_GRAPH);
+  ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
+}


### PR DESCRIPTION
The dijkstra() a boruvka() algorithms of CXXGraph (and perhaps others, but we used these two) are non-deterministic; ie they return different results for the same input under some conditions; especially on different platforms (Windows vs Linux).

This is problematic:
1)It breaks unit tests.
2)It introduces non-determinism to the whole program, which is deadly when you want to reproduce some problem (it might just not happen again).

So I added deterministic versions of these two algorithms to CXXGraph:

boruvka_deterministic()
dijkstra_deterministic()
dijkstra_deterministic2()

They work as the original ones, but always return the same result for the same input, not matter the platform.
Well, almost:

dijkstra_deterministic() uses this method of ensuring determinism:
[https://stackoverflow.com/questions/69649312/how-to-specify-tie-breaking-logic-in-boost-dijkstra-shortest-paths-dijkstra?noredirect=1&lq=1](https://stackoverflow.com/questions/69649312/how-to-specify-tie-breaking-logic-in-boost-dijkstra-shortest-paths-dijkstra?noredirect=1&lq=1)

But the method can still introduce non-determinism in some very special cases
(namely, two paths have the same length(weights sum) AND the same sum of vertex ids, which is improbable, but can happen).

So I added
dijkstra_deterministic2()
which lexicographically compares the whole paths. This assures 100% determinism; but it is a bit more spatially and temporaly intensive.
So I have kept both versions and let the user choose the version he prefers (99% determinism, or 100% determinism at a cost).
