### PR TITLE
Fix incorrectly copied code

### DIFF
--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -707,7 +707,7 @@ const std::unordered_set<shared<const Edge<T>>, edgeHash<T>>
 Graph<T>::inOutEdges(const Node<T> *node) const {
   auto node_shared = make_shared<const Node<T>>(*node);
 
-  return outEdges(node_shared);
+  return inOutEdges(node_shared);
 }
 
 template <typename T>


### PR DESCRIPTION
This code looks like it was incorrectly copied from the `outEdges` overload for pointers. The test suite fails and ultimately segfaults for me, so I did not add an accompanying test.