### PR TITLE
fix tarjan algorithm

### DIFF
--- a/include/CXXGraph/Graph/Algorithm/Tarjan_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Tarjan_impl.hpp
@@ -148,9 +148,7 @@ const TarjanResult<T> Graph<T>::tarjan(const unsigned int typeMask) const {
               // it's not allowed to go through the previous edge back
               // for a directed graph, it's also not allowed to visit
               // a node that is not in stack
-              lowestDisc[curNode->getId()] =
-                  std::min(lowestDisc[curNode->getId()],
-                           lowestDisc[neighborNode->getId()]);
+              lowestDisc[curNode->getId()] = std::min(lowestDisc[curNode->getId()], discoveryTime[neighborNode->getId()]);
             }
           }
         }


### PR DESCRIPTION
- #408 
- when a neighbor node doesn't finish its dfs_helper, use its discoveryTime instead of lowestDisc to update lowestDisc of the current node.
- @ZigRazor @bbannier @Gonzalo-Mier @gitter-badger @nrkramer 

All 300 unit tests passed.

To explain the correctness of the modified version:

> **For any node, discoveryTime[node] >= lowestDisc[node].**
PROOF:
because lowestDisc is initialized with discoveryTime,
and may be updated by smaller values.

> **If a node finishes its dfs_helper, its lowestDisc is the true value,
otherwise its lowestDisc may be greater than the true value.**
_Therefore the first time to update lowestDisc[curNode] in file Tarjan_impl.hpp shall be unchanged._
PROOF:
because in the process of the node's dfs_helper,
lowestDisc[node] may be updated smaller by lowestDisc of any of its neighbor node,
after the neighbor node finishes its dfs_helper.

> **If we are in curNode's dfs_helper, and neighborNode we are traversing is already discovered, then
neighborNode doesn't finish its dfs_helper when the graph is undirected,
and hence lowestDisc[neighborNode] may be greater.**
PROOF by contradiction:
suppose to the contrary that neighborNode finishes its dfs_helper.
Noting that neighborNode and curNode are adjacent in the undirected graph,
and that discoveryTime[neighborNode] < discoveryTime[curNode],
we can conclude that curNode must also finish its dfs_helper,
violating that we are in curNode's dfs_helper.

> _For the second time to update lowestDisc[curNode] in file Tarjan_impl.hpp,
replacing lowestDisc[neighborNode] with discoveryTime[neighborNode] is correct
when the graph is undirected._
PROOF:
we can verify each case.
case TARJAN_FIND_BRIDGE.
####if (discoveryTime[curNode] < lowestDisc[neighborNode]) then curNode-neighborNode is a bridge.
####if (discoveryTime[curNode] < lowestDisc[neighborNode]) is false for all curNode's neighbors, then
########curNode-neighborNode is not a bridge.
case TARJAN_FIND_CUTV.
####if (curNode not root node and discoveryTime[curNode] <= lowestDisc[neighborNode]), then
########curNode is a cut vertex. (This case needs discreetly consider the traversal order of nodes.)
####otherwise of course holds true.
case TARJAN_FIND_VBCC.
####similar to case TARJAN_FIND_CUTV.
case TARJAN_FIND_SCC  or TARJAN_FIND_EBCC.
####similar to case TARJAN_FIND_CUTV.

The above pipeline only demonstrates the correctness of any TASK for UNDIRECTED graph.
For other TASKs with DIRECTED graph and neighborNode inStack,
it needs to be considered carefully,
and perhaps a better choice is to add more unit tests.
