### PR TITLE
Windows builds are broken due to MSVC fold expression bug

### DIFF
--- a/include/CXXGraph/Edge/Edge_impl.hpp
+++ b/include/CXXGraph/Edge/Edge_impl.hpp
@@ -84,8 +84,8 @@ const unsigned long long Edge<T>::getId() const {
 }
 
 template <typename T>
-const std::pair<shared<const Node<T>>, shared<const Node<T>>>
-    &Edge<T>::getNodePair() const {
+const std::pair<shared<const Node<T>>, shared<const Node<T>>> &
+Edge<T>::getNodePair() const {
   return nodePair;
 }
 

--- a/include/CXXGraph/Edge/Edge_impl.hpp
+++ b/include/CXXGraph/Edge/Edge_impl.hpp
@@ -84,8 +84,8 @@ const unsigned long long Edge<T>::getId() const {
 }
 
 template <typename T>
-const std::pair<shared<const Node<T>>, shared<const Node<T>>> &
-Edge<T>::getNodePair() const {
+const std::pair<shared<const Node<T>>, shared<const Node<T>>>
+    &Edge<T>::getNodePair() const {
   return nodePair;
 }
 

--- a/include/CXXGraph/Graph/Algorithm/Boruvka_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Boruvka_impl.hpp
@@ -187,16 +187,16 @@ const MstResult Graph<T>::boruvka_deterministic() const {
       // Else check if current edge is closer to previous
       // cheapest edges of set1 and set2
       if (cheapest[set1] == INT_MAX ||
-                (edgeWeight[cheapest[set1]] > edgeWeight[edgeId]) ||
-                (edgeWeight[cheapest[set1]] == edgeWeight[edgeId] && cheapest[set1] > edgeId)
-          )
-          cheapest[set1] = edgeId;
+          (edgeWeight[cheapest[set1]] > edgeWeight[edgeId]) ||
+          (edgeWeight[cheapest[set1]] == edgeWeight[edgeId] &&
+           cheapest[set1] > edgeId))
+        cheapest[set1] = edgeId;
 
       if (cheapest[set2] == INT_MAX ||
-                (edgeWeight[cheapest[set2]] > edgeWeight[edgeId]) ||
-                (edgeWeight[cheapest[set2]] == edgeWeight[edgeId] && cheapest[set2] > edgeId)
-          )
-          cheapest[set2] = edgeId;
+          (edgeWeight[cheapest[set2]] > edgeWeight[edgeId]) ||
+          (edgeWeight[cheapest[set2]] == edgeWeight[edgeId] &&
+           cheapest[set2] > edgeId))
+        cheapest[set2] = edgeId;
     }
 
     // iterate over all the vertices and add picked

--- a/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
@@ -26,8 +26,8 @@
 
 namespace CXXGraph {
 template <typename T>
-const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
-                                        const Node<T> &target) const {
+const DijkstraResult Graph<T>::dijkstra(const Node<T>& source,
+                                        const Node<T>& target) const {
   DijkstraResult result;
   auto nodeSet = Graph<T>::getNodeSet();
 
@@ -54,7 +54,7 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
   // setting all the distances initially to INF_DOUBLE
   std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
 
-  for (const auto &node : nodeSet) {
+  for (const auto& node : nodeSet) {
     dist[node] = INF_DOUBLE;
   }
 
@@ -86,7 +86,7 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
     // for all the reachable vertex from the currently exploring vertex
     // we will try to minimize the distance
     if (cachedAdjMatrix->find(currentNode) != cachedAdjMatrix->end()) {
-      for (const auto &elem : cachedAdjMatrix->at(currentNode)) {
+      for (const auto& elem : cachedAdjMatrix->at(currentNode)) {
         // minimizing distances
         if (elem.second->isWeighted().has_value() &&
             elem.second->isWeighted().value()) {
@@ -150,317 +150,305 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T> &source,
 }
 
 template <typename T>
-const DijkstraResult Graph<T>::dijkstra_deterministic(const Node<T>& source,
-                                                      const Node<T>& target) const {
-    DijkstraResult result;
-    auto nodeSet = Graph<T>::getNodeSet();
+const DijkstraResult Graph<T>::dijkstra_deterministic(
+    const Node<T>& source, const Node<T>& target) const {
+  DijkstraResult result;
+  auto nodeSet = Graph<T>::getNodeSet();
 
-    auto source_node_it = std::find_if(
-        nodeSet.begin(), nodeSet.end(),
-        [&source](auto node) { return node->getUserId() == source.getUserId(); });
-    if (source_node_it == nodeSet.end()) {
-        // check if source node exist in the graph
-        result.errorMessage = ERR_SOURCE_NODE_NOT_IN_GRAPH;
-        return result;
-    }
-
-    auto target_node_it = std::find_if(
-        nodeSet.begin(), nodeSet.end(),
-        [&target](auto node) { return node->getUserId() == target.getUserId(); });
-    if (target_node_it == nodeSet.end()) {
-        // check if target node exist in the graph
-        result.errorMessage = ERR_TARGET_NODE_NOT_IN_GRAPH;
-        return result;
-    }
-    // n denotes the number of vertices in graph
-    auto n = cachedAdjMatrix->size();
-
-    // setting all the distances initially to INF_DOUBLE
-    std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
-    std::map<std::string, shared<const Node<T>>> userIds;
-
-    for (const auto& node : nodeSet) {
-        dist[node] = INF_DOUBLE;
-        userIds[node->getUserId()] = node;        
-    }
-
-    std::unordered_map<shared<const Node<T>>, size_t, nodeHash<T>> stableIds;
-    size_t index(0);
-    for (const auto& it : userIds)
-        stableIds[it.second] = index++;
-
-    // creating a min heap using priority queue
-    // first element of pair contains the distance
-    // second element of pair contains the vertex
-
-    struct VertexInfo
-    {
-        double distance = 0;
-        size_t sumOfIds = 0;
-        shared<const Node<T>> node;
-    };
-
-    struct VertexInfoGreater
-    {
-        bool operator()(const VertexInfo& a, const VertexInfo& b) const
-        {
-            if (a.distance == b.distance) 
-                return a.sumOfIds > b.sumOfIds;
-            return a.distance > b.distance;
-        };
-    };
-        
-    std::priority_queue<VertexInfo,
-        std::vector<VertexInfo>,
-        VertexInfoGreater>
-        pq;
-
-    // pushing the source vertex 's' with 0 distance in min heap
-    pq.push(VertexInfo{ 0.0, stableIds[*source_node_it], *source_node_it });
-
-    // marking the distance of source as 0
-    dist[*source_node_it] = 0;
-
-    std::unordered_map<std::string, std::string> parent;
-    parent[source.getUserId()] = "";
-
-    while (!pq.empty()) {
-        // second element of pair denotes the node / vertex
-        shared<const Node<T>> currentNode = pq.top().node;
-        // first element of pair denotes the distance
-        double currentDist = pq.top().distance;
-        auto currentNodesSum = pq.top().sumOfIds;
-
-        pq.pop();
-
-        // for all the reachable vertex from the currently exploring vertex
-        // we will try to minimize the distance
-        if (cachedAdjMatrix->find(currentNode) != cachedAdjMatrix->end()) {
-            for (const auto& elem : cachedAdjMatrix->at(currentNode)) {
-                // minimizing distances
-                if (elem.second->isWeighted().has_value() &&
-                    elem.second->isWeighted().value()) {
-                    if (elem.second->isDirected().has_value() &&
-                        elem.second->isDirected().value()) {
-                        shared<const DirectedWeightedEdge<T>> dw_edge =
-                            std::static_pointer_cast<const DirectedWeightedEdge<T>>(
-                                elem.second);
-                        if (dw_edge->getWeight() < 0) {
-                            result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
-                            return result;
-                        }
-                        else if (currentDist + dw_edge->getWeight() < dist[elem.first]) {
-                            dist[elem.first] = currentDist + dw_edge->getWeight();
-                            pq.push(VertexInfo{ dist[elem.first], currentNodesSum + stableIds[elem.first], elem.first });
-                            parent[elem.first.get()->getUserId()] =
-                              currentNode.get()->getUserId();
-                        }
-                    }
-                    else if (elem.second->isDirected().has_value() &&
-                        !elem.second->isDirected().value()) {
-                        shared<const UndirectedWeightedEdge<T>> udw_edge =
-                            std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
-                                elem.second);
-                        if (udw_edge->getWeight() < 0) {
-                            result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
-                            return result;
-                        }
-                        else if (currentDist + udw_edge->getWeight() < dist[elem.first]) {
-                            dist[elem.first] = currentDist + udw_edge->getWeight();
-                            pq.push(VertexInfo{ dist[elem.first], currentNodesSum + stableIds[elem.first], elem.first });
-                            parent[elem.first.get()->getUserId()] = currentNode.get()->getUserId();
-                        }
-                    }
-                    else {
-                        // ERROR it shouldn't never returned ( does not exist a Node
-                        // Weighted and not Directed/Undirected)
-                        result.errorMessage = ERR_NO_DIR_OR_UNDIR_EDGE;
-                        return result;
-                    }
-                }
-                else {
-                    // No Weighted Edge
-                    result.errorMessage = ERR_NO_WEIGHTED_EDGE;
-                    return result;
-                }
-            }
-        }
-    }
-    if (dist[*target_node_it] != INF_DOUBLE) {
-        result.success = true;
-        result.errorMessage = "";
-        result.result = dist[*target_node_it];
-        std::string id = target.getUserId();
-        while (parent[id] != "") {
-            result.path.push_back(id);
-            id = parent[id];
-        }
-        result.path.push_back(source.getUserId());
-        std::reverse(result.path.begin(), result.path.end());
-        return result;
-    }
-    result.errorMessage = ERR_TARGET_NODE_NOT_REACHABLE;
+  auto source_node_it = std::find_if(
+      nodeSet.begin(), nodeSet.end(),
+      [&source](auto node) { return node->getUserId() == source.getUserId(); });
+  if (source_node_it == nodeSet.end()) {
+    // check if source node exist in the graph
+    result.errorMessage = ERR_SOURCE_NODE_NOT_IN_GRAPH;
     return result;
+  }
+
+  auto target_node_it = std::find_if(
+      nodeSet.begin(), nodeSet.end(),
+      [&target](auto node) { return node->getUserId() == target.getUserId(); });
+  if (target_node_it == nodeSet.end()) {
+    // check if target node exist in the graph
+    result.errorMessage = ERR_TARGET_NODE_NOT_IN_GRAPH;
+    return result;
+  }
+  // n denotes the number of vertices in graph
+  auto n = cachedAdjMatrix->size();
+
+  // setting all the distances initially to INF_DOUBLE
+  std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
+  std::map<std::string, shared<const Node<T>>> userIds;
+
+  for (const auto& node : nodeSet) {
+    dist[node] = INF_DOUBLE;
+    userIds[node->getUserId()] = node;
+  }
+
+  std::unordered_map<shared<const Node<T>>, size_t, nodeHash<T>> stableIds;
+  size_t index(0);
+  for (const auto& it : userIds) stableIds[it.second] = index++;
+
+  // creating a min heap using priority queue
+  // first element of pair contains the distance
+  // second element of pair contains the vertex
+
+  struct VertexInfo {
+    double distance = 0;
+    size_t sumOfIds = 0;
+    shared<const Node<T>> node;
+  };
+
+  struct VertexInfoGreater {
+    bool operator()(const VertexInfo& a, const VertexInfo& b) const {
+      if (a.distance == b.distance) return a.sumOfIds > b.sumOfIds;
+      return a.distance > b.distance;
+    };
+  };
+
+  std::priority_queue<VertexInfo, std::vector<VertexInfo>, VertexInfoGreater>
+      pq;
+
+  // pushing the source vertex 's' with 0 distance in min heap
+  pq.push(VertexInfo{0.0, stableIds[*source_node_it], *source_node_it});
+
+  // marking the distance of source as 0
+  dist[*source_node_it] = 0;
+
+  std::unordered_map<std::string, std::string> parent;
+  parent[source.getUserId()] = "";
+
+  while (!pq.empty()) {
+    // second element of pair denotes the node / vertex
+    shared<const Node<T>> currentNode = pq.top().node;
+    // first element of pair denotes the distance
+    double currentDist = pq.top().distance;
+    auto currentNodesSum = pq.top().sumOfIds;
+
+    pq.pop();
+
+    // for all the reachable vertex from the currently exploring vertex
+    // we will try to minimize the distance
+    if (cachedAdjMatrix->find(currentNode) != cachedAdjMatrix->end()) {
+      for (const auto& elem : cachedAdjMatrix->at(currentNode)) {
+        // minimizing distances
+        if (elem.second->isWeighted().has_value() &&
+            elem.second->isWeighted().value()) {
+          if (elem.second->isDirected().has_value() &&
+              elem.second->isDirected().value()) {
+            shared<const DirectedWeightedEdge<T>> dw_edge =
+                std::static_pointer_cast<const DirectedWeightedEdge<T>>(
+                    elem.second);
+            if (dw_edge->getWeight() < 0) {
+              result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
+              return result;
+            } else if (currentDist + dw_edge->getWeight() < dist[elem.first]) {
+              dist[elem.first] = currentDist + dw_edge->getWeight();
+              pq.push(VertexInfo{dist[elem.first],
+                                 currentNodesSum + stableIds[elem.first],
+                                 elem.first});
+              parent[elem.first.get()->getUserId()] =
+                  currentNode.get()->getUserId();
+            }
+          } else if (elem.second->isDirected().has_value() &&
+                     !elem.second->isDirected().value()) {
+            shared<const UndirectedWeightedEdge<T>> udw_edge =
+                std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
+                    elem.second);
+            if (udw_edge->getWeight() < 0) {
+              result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
+              return result;
+            } else if (currentDist + udw_edge->getWeight() < dist[elem.first]) {
+              dist[elem.first] = currentDist + udw_edge->getWeight();
+              pq.push(VertexInfo{dist[elem.first],
+                                 currentNodesSum + stableIds[elem.first],
+                                 elem.first});
+              parent[elem.first.get()->getUserId()] =
+                  currentNode.get()->getUserId();
+            }
+          } else {
+            // ERROR it shouldn't never returned ( does not exist a Node
+            // Weighted and not Directed/Undirected)
+            result.errorMessage = ERR_NO_DIR_OR_UNDIR_EDGE;
+            return result;
+          }
+        } else {
+          // No Weighted Edge
+          result.errorMessage = ERR_NO_WEIGHTED_EDGE;
+          return result;
+        }
+      }
+    }
+  }
+  if (dist[*target_node_it] != INF_DOUBLE) {
+    result.success = true;
+    result.errorMessage = "";
+    result.result = dist[*target_node_it];
+    std::string id = target.getUserId();
+    while (parent[id] != "") {
+      result.path.push_back(id);
+      id = parent[id];
+    }
+    result.path.push_back(source.getUserId());
+    std::reverse(result.path.begin(), result.path.end());
+    return result;
+  }
+  result.errorMessage = ERR_TARGET_NODE_NOT_REACHABLE;
+  return result;
 }
 
 template <typename T>
-const DijkstraResult Graph<T>::dijkstra_deterministic2(const Node<T>& source,
-                                                       const Node<T>& target) const {
-    DijkstraResult result;
-    auto nodeSet = Graph<T>::getNodeSet();
+const DijkstraResult Graph<T>::dijkstra_deterministic2(
+    const Node<T>& source, const Node<T>& target) const {
+  DijkstraResult result;
+  auto nodeSet = Graph<T>::getNodeSet();
 
-    auto source_node_it = std::find_if(
-        nodeSet.begin(), nodeSet.end(),
-        [&source](auto node) { return node->getUserId() == source.getUserId(); });
-    if (source_node_it == nodeSet.end()) {
-        // check if source node exist in the graph
-        result.errorMessage = ERR_SOURCE_NODE_NOT_IN_GRAPH;
-        return result;
-    }
-
-    auto target_node_it = std::find_if(
-        nodeSet.begin(), nodeSet.end(),
-        [&target](auto node) { return node->getUserId() == target.getUserId(); });
-    if (target_node_it == nodeSet.end()) {
-        // check if target node exist in the graph
-        result.errorMessage = ERR_TARGET_NODE_NOT_IN_GRAPH;
-        return result;
-    }
-    // n denotes the number of vertices in graph
-    auto n = cachedAdjMatrix->size();
-
-    // setting all the distances initially to INF_DOUBLE
-    std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
-    std::map<std::string, shared<const Node<T>>> userIds;
-
-    for (const auto& node : nodeSet) {
-        dist[node] = INF_DOUBLE;
-        userIds[node->getUserId()] = node;
-    }
-
-    std::unordered_map<shared<const Node<T>>, uint64_t, nodeHash<T>> stableIds;
-    size_t index(0);
-    for (const auto& it : userIds)
-        stableIds[it.second] = index++;
-
-    // creating a min heap using priority queue
-    // first element of pair contains the distance
-    // second element of pair contains the vertex
-
-    struct VertexInfo
-    {
-        double distance = 0;
-        std::vector<size_t> pathToVertex;
-        shared<const Node<T>> node;
-    };
-
-    struct VertexInfoGreater
-    {
-        bool operator()(const VertexInfo& a, const VertexInfo& b) const
-        {
-            if (a.distance == b.distance)
-                return std::lexicographical_compare(begin(b.pathToVertex), end(b.pathToVertex), begin(a.pathToVertex), end(a.pathToVertex));
-            return a.distance > b.distance;
-        };
-    };
-
-    auto addNode = [&](std::vector<size_t> v, const shared<const Node<T>> &node)
-    {
-        v.push_back(stableIds[node]);
-        return v;
-    };
-
-    std::priority_queue<VertexInfo,
-        std::vector<VertexInfo>,
-        VertexInfoGreater>
-        pq;
-
-    // pushing the source vertex 's' with 0 distance in min heap
-    pq.push(VertexInfo{ 0.0, addNode({},*source_node_it), *source_node_it });
-
-    // marking the distance of source as 0
-    dist[*source_node_it] = 0;
-
-    std::unordered_map<std::string, std::string> parent;
-    parent[source.getUserId()] = "";
-
-    while (!pq.empty()) {
-        // second element of pair denotes the node / vertex
-        shared<const Node<T>> currentNode = pq.top().node;
-        // first element of pair denotes the distance
-        double currentDist = pq.top().distance;
-        auto currentNodesPath = pq.top().pathToVertex;
-
-        pq.pop();
-
-        // for all the reachable vertex from the currently exploring vertex
-        // we will try to minimize the distance
-        if (cachedAdjMatrix->find(currentNode) != cachedAdjMatrix->end()) {
-            for (const auto& elem : cachedAdjMatrix->at(currentNode)) {
-                // minimizing distances
-                if (elem.second->isWeighted().has_value() &&
-                    elem.second->isWeighted().value()) {
-                    if (elem.second->isDirected().has_value() &&
-                        elem.second->isDirected().value()) {
-                        shared<const DirectedWeightedEdge<T>> dw_edge =
-                            std::static_pointer_cast<const DirectedWeightedEdge<T>>(
-                                elem.second);
-                        if (dw_edge->getWeight() < 0) {
-                            result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
-                            return result;
-                        }
-                        else if (currentDist + dw_edge->getWeight() < dist[elem.first]) {
-                            dist[elem.first] = currentDist + dw_edge->getWeight();
-                            pq.push(VertexInfo{ dist[elem.first], addNode(currentNodesPath,elem.first), elem.first });
-                            parent[elem.first.get()->getUserId()] =
-                              currentNode.get()->getUserId();
-                        }
-                    }
-                    else if (elem.second->isDirected().has_value() &&
-                        !elem.second->isDirected().value()) {
-                        shared<const UndirectedWeightedEdge<T>> udw_edge =
-                            std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
-                                elem.second);
-                        if (udw_edge->getWeight() < 0) {
-                            result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
-                            return result;
-                        }
-                        else if (currentDist + udw_edge->getWeight() < dist[elem.first]) {
-                            dist[elem.first] = currentDist + udw_edge->getWeight();
-                            pq.push(VertexInfo{ dist[elem.first], addNode(currentNodesPath,elem.first), elem.first });
-                            parent[elem.first.get()->getUserId()] = currentNode.get()->getUserId();
-                        }
-                    }
-                    else {
-                        // ERROR it shouldn't never returned ( does not exist a Node
-                        // Weighted and not Directed/Undirected)
-                        result.errorMessage = ERR_NO_DIR_OR_UNDIR_EDGE;
-                        return result;
-                    }
-                }
-                else {
-                    // No Weighted Edge
-                    result.errorMessage = ERR_NO_WEIGHTED_EDGE;
-                    return result;
-                }
-            }
-        }
-    }
-    if (dist[*target_node_it] != INF_DOUBLE) {
-        result.success = true;
-        result.errorMessage = "";
-        result.result = dist[*target_node_it];
-        std::string id = target.getUserId();
-        while (parent[id] != "") {
-            result.path.push_back(id);
-            id = parent[id];
-        }
-        result.path.push_back(source.getUserId());
-        std::reverse(result.path.begin(), result.path.end());
-        return result;
-    }
-    result.errorMessage = ERR_TARGET_NODE_NOT_REACHABLE;
+  auto source_node_it = std::find_if(
+      nodeSet.begin(), nodeSet.end(),
+      [&source](auto node) { return node->getUserId() == source.getUserId(); });
+  if (source_node_it == nodeSet.end()) {
+    // check if source node exist in the graph
+    result.errorMessage = ERR_SOURCE_NODE_NOT_IN_GRAPH;
     return result;
+  }
+
+  auto target_node_it = std::find_if(
+      nodeSet.begin(), nodeSet.end(),
+      [&target](auto node) { return node->getUserId() == target.getUserId(); });
+  if (target_node_it == nodeSet.end()) {
+    // check if target node exist in the graph
+    result.errorMessage = ERR_TARGET_NODE_NOT_IN_GRAPH;
+    return result;
+  }
+  // n denotes the number of vertices in graph
+  auto n = cachedAdjMatrix->size();
+
+  // setting all the distances initially to INF_DOUBLE
+  std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
+  std::map<std::string, shared<const Node<T>>> userIds;
+
+  for (const auto& node : nodeSet) {
+    dist[node] = INF_DOUBLE;
+    userIds[node->getUserId()] = node;
+  }
+
+  std::unordered_map<shared<const Node<T>>, uint64_t, nodeHash<T>> stableIds;
+  size_t index(0);
+  for (const auto& it : userIds) stableIds[it.second] = index++;
+
+  // creating a min heap using priority queue
+  // first element of pair contains the distance
+  // second element of pair contains the vertex
+
+  struct VertexInfo {
+    double distance = 0;
+    std::vector<size_t> pathToVertex;
+    shared<const Node<T>> node;
+  };
+
+  struct VertexInfoGreater {
+    bool operator()(const VertexInfo& a, const VertexInfo& b) const {
+      if (a.distance == b.distance)
+        return std::lexicographical_compare(
+            begin(b.pathToVertex), end(b.pathToVertex), begin(a.pathToVertex),
+            end(a.pathToVertex));
+      return a.distance > b.distance;
+    };
+  };
+
+  auto addNode = [&](std::vector<size_t> v, const shared<const Node<T>>& node) {
+    v.push_back(stableIds[node]);
+    return v;
+  };
+
+  std::priority_queue<VertexInfo, std::vector<VertexInfo>, VertexInfoGreater>
+      pq;
+
+  // pushing the source vertex 's' with 0 distance in min heap
+  pq.push(VertexInfo{0.0, addNode({}, *source_node_it), *source_node_it});
+
+  // marking the distance of source as 0
+  dist[*source_node_it] = 0;
+
+  std::unordered_map<std::string, std::string> parent;
+  parent[source.getUserId()] = "";
+
+  while (!pq.empty()) {
+    // second element of pair denotes the node / vertex
+    shared<const Node<T>> currentNode = pq.top().node;
+    // first element of pair denotes the distance
+    double currentDist = pq.top().distance;
+    auto currentNodesPath = pq.top().pathToVertex;
+
+    pq.pop();
+
+    // for all the reachable vertex from the currently exploring vertex
+    // we will try to minimize the distance
+    if (cachedAdjMatrix->find(currentNode) != cachedAdjMatrix->end()) {
+      for (const auto& elem : cachedAdjMatrix->at(currentNode)) {
+        // minimizing distances
+        if (elem.second->isWeighted().has_value() &&
+            elem.second->isWeighted().value()) {
+          if (elem.second->isDirected().has_value() &&
+              elem.second->isDirected().value()) {
+            shared<const DirectedWeightedEdge<T>> dw_edge =
+                std::static_pointer_cast<const DirectedWeightedEdge<T>>(
+                    elem.second);
+            if (dw_edge->getWeight() < 0) {
+              result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
+              return result;
+            } else if (currentDist + dw_edge->getWeight() < dist[elem.first]) {
+              dist[elem.first] = currentDist + dw_edge->getWeight();
+              pq.push(VertexInfo{dist[elem.first],
+                                 addNode(currentNodesPath, elem.first),
+                                 elem.first});
+              parent[elem.first.get()->getUserId()] =
+                  currentNode.get()->getUserId();
+            }
+          } else if (elem.second->isDirected().has_value() &&
+                     !elem.second->isDirected().value()) {
+            shared<const UndirectedWeightedEdge<T>> udw_edge =
+                std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
+                    elem.second);
+            if (udw_edge->getWeight() < 0) {
+              result.errorMessage = ERR_NEGATIVE_WEIGHTED_EDGE;
+              return result;
+            } else if (currentDist + udw_edge->getWeight() < dist[elem.first]) {
+              dist[elem.first] = currentDist + udw_edge->getWeight();
+              pq.push(VertexInfo{dist[elem.first],
+                                 addNode(currentNodesPath, elem.first),
+                                 elem.first});
+              parent[elem.first.get()->getUserId()] =
+                  currentNode.get()->getUserId();
+            }
+          } else {
+            // ERROR it shouldn't never returned ( does not exist a Node
+            // Weighted and not Directed/Undirected)
+            result.errorMessage = ERR_NO_DIR_OR_UNDIR_EDGE;
+            return result;
+          }
+        } else {
+          // No Weighted Edge
+          result.errorMessage = ERR_NO_WEIGHTED_EDGE;
+          return result;
+        }
+      }
+    }
+  }
+  if (dist[*target_node_it] != INF_DOUBLE) {
+    result.success = true;
+    result.errorMessage = "";
+    result.result = dist[*target_node_it];
+    std::string id = target.getUserId();
+    while (parent[id] != "") {
+      result.path.push_back(id);
+      id = parent[id];
+    }
+    result.path.push_back(source.getUserId());
+    std::reverse(result.path.begin(), result.path.end());
+    return result;
+  }
+  result.errorMessage = ERR_TARGET_NODE_NOT_REACHABLE;
+  return result;
 }
 
 }  // namespace CXXGraph

--- a/include/CXXGraph/Graph/Algorithm/Tarjan_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Tarjan_impl.hpp
@@ -148,7 +148,9 @@ const TarjanResult<T> Graph<T>::tarjan(const unsigned int typeMask) const {
               // it's not allowed to go through the previous edge back
               // for a directed graph, it's also not allowed to visit
               // a node that is not in stack
-              lowestDisc[curNode->getId()] = std::min(lowestDisc[curNode->getId()], discoveryTime[neighborNode->getId()]);
+              lowestDisc[curNode->getId()] =
+                  std::min(lowestDisc[curNode->getId()],
+                           discoveryTime[neighborNode->getId()]);
             }
           }
         }

--- a/include/CXXGraph/Graph/Algorithm/welshPowellColoring_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/welshPowellColoring_impl.hpp
@@ -17,7 +17,7 @@ std::map<Node<T>, int> Graph<T>::welshPowellColoring() const {
   std::vector<std::pair<std::shared_ptr<const Node<T>>, int>> degreeOfVertexVector = {};
   // Find the degree of each vertex and put them in a vector
   for (const auto &[nodeFrom, nodeToEdgeVec] : adjMatrix) {
-    degreeOfVertexVector.push_back({nodeFrom, nodeToEdgeVec.size()});
+    degreeOfVertexVector.push_back({nodeFrom, (int)nodeToEdgeVec.size()});
   }
 
   // Sort them based on the vertex degree
@@ -42,7 +42,7 @@ std::map<Node<T>, int> Graph<T>::welshPowellColoring() const {
 
     // Assign the smallest unused color to the current vertex
 	auto it = std::find(usedColors.begin() + 1, usedColors.end(), 0);
-	mapOfColoring[*node] = std::distance(usedColors.begin(), it);
+	mapOfColoring[*node] = (int)std::distance(usedColors.begin(), it);
   }
 
   return mapOfColoring;

--- a/include/CXXGraph/Graph/Algorithm/welshPowellColoring_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/welshPowellColoring_impl.hpp
@@ -14,20 +14,23 @@ template <typename T>
 std::map<Node<T>, int> Graph<T>::welshPowellColoring() const {
   auto adjMatrix = *getAdjMatrix();
 
-  std::vector<std::pair<std::shared_ptr<const Node<T>>, int>> degreeOfVertexVector = {};
+  std::vector<std::pair<std::shared_ptr<const Node<T>>, int>>
+      degreeOfVertexVector = {};
   // Find the degree of each vertex and put them in a vector
-  for (const auto &[nodeFrom, nodeToEdgeVec] : adjMatrix) {
+  for (const auto& [nodeFrom, nodeToEdgeVec] : adjMatrix) {
     degreeOfVertexVector.push_back({nodeFrom, (int)nodeToEdgeVec.size()});
   }
 
   // Sort them based on the vertex degree
-  std::sort(degreeOfVertexVector.begin(), degreeOfVertexVector.end(), [](const auto& left, const auto& right) {
-    return left.second > right.second;
-  });
+  std::sort(degreeOfVertexVector.begin(), degreeOfVertexVector.end(),
+            [](const auto& left, const auto& right) {
+              return left.second > right.second;
+            });
 
-  // Create a new map of coloring, where the keys a	re the nodes, and the value is the color order (assigned by integer)
+  // Create a new map of coloring, where the keys a	re the nodes, and the
+  // value is the color order (assigned by integer)
   std::map<Node<T>, int> mapOfColoring;
-  for (const auto &[nodeFrom, _] : adjMatrix) {
+  for (const auto& [nodeFrom, _] : adjMatrix) {
     mapOfColoring[*nodeFrom] = 0;
   }
 
@@ -35,17 +38,17 @@ std::map<Node<T>, int> Graph<T>::welshPowellColoring() const {
   std::vector<int> usedColors(degreeOfVertexVector.size() + 1, 0);
   for (const auto& [node, _] : degreeOfVertexVector) {
     // Find the smallest unused color for the current vertex
-	std::fill(usedColors.begin(), usedColors.end(), 0);
-    for (const auto &[neighbor, _] : adjMatrix[node]) {
+    std::fill(usedColors.begin(), usedColors.end(), 0);
+    for (const auto& [neighbor, _] : adjMatrix[node]) {
       usedColors[mapOfColoring[*neighbor]] = 1;
     }
 
     // Assign the smallest unused color to the current vertex
-	auto it = std::find(usedColors.begin() + 1, usedColors.end(), 0);
-	mapOfColoring[*node] = (int)std::distance(usedColors.begin(), it);
+    auto it = std::find(usedColors.begin() + 1, usedColors.end(), 0);
+    mapOfColoring[*node] = (int)std::distance(usedColors.begin(), it);
   }
 
   return mapOfColoring;
 }
-}
+}  // namespace CXXGraph
 #endif  // CXXGRAPH_WELSHPOWELLCOLORING_IMPL_H__

--- a/include/CXXGraph/Graph/Graph_decl.h
+++ b/include/CXXGraph/Graph/Graph_decl.h
@@ -173,8 +173,8 @@ class Graph {
    *
    */
   template <typename T1, typename... Tn>
-  std::enable_if_t<all_are_edge_ptrs_v<T1, Tn...>, void>
-  addEdges(T1 edge, Tn... edges);
+  std::enable_if_t<all_are_edge_ptrs_v<T1, Tn...>, void> addEdges(T1 edge,
+                                                                  Tn... edges);
   /**
    * \brief
    * Function to add a Node to the Graph Node Set
@@ -211,8 +211,8 @@ class Graph {
    *
    */
   template <typename T1, typename... Tn>
-  std::enable_if_t<all_are_node_ptrs_v<T1, Tn...>, void>
-  addNodes(T1 node, Tn... nodes);
+  std::enable_if_t<all_are_node_ptrs_v<T1, Tn...>, void> addNodes(T1 node,
+                                                                  Tn... nodes);
   /**
    * \brief
    * Function remove an Edge from the Graph Edge Set
@@ -495,10 +495,10 @@ class Graph {
    */
   virtual const DijkstraResult dijkstra(const Node<T> &source,
                                         const Node<T> &target) const;
-  virtual const DijkstraResult dijkstra_deterministic(const Node<T> &source,
-                                        const Node<T> &target) const;
-  virtual const DijkstraResult dijkstra_deterministic2(const Node<T> &source,
-                                        const Node<T> &target) const;  
+  virtual const DijkstraResult dijkstra_deterministic(
+      const Node<T> &source, const Node<T> &target) const;
+  virtual const DijkstraResult dijkstra_deterministic2(
+      const Node<T> &source, const Node<T> &target) const;
   /**
    * @brief This function runs the tarjan algorithm and returns different types
    * of results depending on the input parameter typeMask.
@@ -801,15 +801,15 @@ class Graph {
                                       const Node<T> &target) const;
 
   /**
-    * @brief Welsh-Powell Coloring algorithm
-    * @return a std::map of keys being the nodes and the values being the color
-    * order (by integer) starting from 1.
-    * Source :
-    *          https://www.youtube.com/watch?v=SLkyDuG1Puw&ab_channel=TheLogicalLearning
-    *          https://www.geeksforgeeks.org/welsh-powell-graph-colouring-algorithm/
-    *          https://www.tutorialspoint.com/de-powell-graph-colouring-algorithm
+   * @brief Welsh-Powell Coloring algorithm
+   * @return a std::map of keys being the nodes and the values being the color
+   * order (by integer) starting from 1.
+   * Source :
+   *          https://www.youtube.com/watch?v=SLkyDuG1Puw&ab_channel=TheLogicalLearning
+   *          https://www.geeksforgeeks.org/welsh-powell-graph-colouring-algorithm/
+   *          https://www.tutorialspoint.com/de-powell-graph-colouring-algorithm
    */
-  virtual std::map<Node<T>, int> welshPowellColoring()  const;
+  virtual std::map<Node<T>, int> welshPowellColoring() const;
 
   /**
    * \brief

--- a/include/CXXGraph/Graph/Graph_decl.h
+++ b/include/CXXGraph/Graph/Graph_decl.h
@@ -173,7 +173,7 @@ class Graph {
    *
    */
   template <typename T1, typename... Tn>
-  std::enable_if_t<is_edge_ptr_v<T1> && (is_edge_ptr_v<Tn> && ...), void>
+  std::enable_if_t<all_are_edge_ptrs_v<T1, Tn...>, void>
   addEdges(T1 edge, Tn... edges);
   /**
    * \brief
@@ -211,7 +211,7 @@ class Graph {
    *
    */
   template <typename T1, typename... Tn>
-  std::enable_if_t<is_node_ptr_v<T1> && (is_node_ptr_v<Tn> && ...), void>
+  std::enable_if_t<all_are_node_ptrs_v<T1, Tn...>, void>
   addNodes(T1 node, Tn... nodes);
   /**
    * \brief

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -152,8 +152,8 @@ void Graph<T>::addEdges() {
 
 template <typename T>
 template <typename T1, typename... Tn>
-std::enable_if_t<all_are_edge_ptrs_v<T1, Tn...>, void>
-Graph<T>::addEdges(T1 edge, Tn... edges) {
+std::enable_if_t<all_are_edge_ptrs_v<T1, Tn...>, void> Graph<T>::addEdges(
+    T1 edge, Tn... edges) {
   addEdge(edge);
   addEdges(edges...);
 }
@@ -177,8 +177,8 @@ void Graph<T>::addNodes() {
 
 template <typename T>
 template <typename T1, typename... Tn>
-std::enable_if_t<all_are_node_ptrs_v<T1, Tn...>, void>
-Graph<T>::addNodes(T1 node, Tn... nodes) {
+std::enable_if_t<all_are_node_ptrs_v<T1, Tn...>, void> Graph<T>::addNodes(
+    T1 node, Tn... nodes) {
   addNode(node);
   addNodes(nodes...);
 }

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -152,7 +152,7 @@ void Graph<T>::addEdges() {
 
 template <typename T>
 template <typename T1, typename... Tn>
-std::enable_if_t<is_edge_ptr_v<T1> && (is_edge_ptr_v<Tn> && ...), void>
+std::enable_if_t<all_are_edge_ptrs_v<T1, Tn...>, void>
 Graph<T>::addEdges(T1 edge, Tn... edges) {
   addEdge(edge);
   addEdges(edges...);
@@ -177,7 +177,7 @@ void Graph<T>::addNodes() {
 
 template <typename T>
 template <typename T1, typename... Tn>
-std::enable_if_t<is_node_ptr_v<T1> && (is_node_ptr_v<Tn> && ...), void>
+std::enable_if_t<all_are_node_ptrs_v<T1, Tn...>, void>
 Graph<T>::addNodes(T1 node, Tn... nodes) {
   addNode(node);
   addNodes(nodes...);
@@ -540,7 +540,7 @@ shared<DegreeMatrix<T>> Graph<T>::getDegreeMatrix() const {
     const std::vector<std::pair<shared<const Node<T>>, shared<const Edge<T>>>>
         &neighbors = nodePair.second;
 
-    int degree = neighbors.size();
+    int degree = (int)neighbors.size();
 
     (*degreeMatrix)[node] = {degree};
   }
@@ -605,7 +605,7 @@ shared<TransitionMatrix<T>> Graph<T>::getTransitionMatrix() const {
     const std::vector<std::pair<shared<const Node<T>>, shared<const Edge<T>>>>
         &neighbors = nodePair.second;
 
-    int degree = neighbors.size();
+    int degree = (int)neighbors.size();
 
     double transitionProbability = 1.0 / degree;
 

--- a/include/CXXGraph/Utility/TypeTraits.hpp
+++ b/include/CXXGraph/Utility/TypeTraits.hpp
@@ -65,6 +65,14 @@ struct is_node_ptr<shared<T>>
 template <typename T>
 inline constexpr bool is_node_ptr_v = is_node_ptr<T>::value;
 
+template<typename T, typename... Ts>
+struct all_are_node_ptrs {
+    static constexpr bool value = (is_node_ptr_v<T> && ... && is_node_ptr_v<Ts>);
+};
+
+template<typename T, typename... Ts>
+inline constexpr bool all_are_node_ptrs_v = all_are_node_ptrs<T, Ts...>::value;
+
 // is_edge type trait
 template <typename T>
 struct is_edge
@@ -94,6 +102,14 @@ struct is_edge_ptr<shared<T>>
 
 template <typename T>
 inline constexpr bool is_edge_ptr_v = is_edge_ptr<T>::value;
+
+template<typename T, typename... Ts>
+struct all_are_edge_ptrs {
+    static constexpr bool value = (is_edge_ptr_v<T> && ... && is_edge_ptr_v<Ts>);
+};
+
+template<typename T, typename... Ts>
+inline constexpr bool all_are_edge_ptrs_v = all_are_edge_ptrs<T, Ts...>::value;
 
 }  // namespace CXXGraph
 

--- a/include/CXXGraph/Utility/TypeTraits.hpp
+++ b/include/CXXGraph/Utility/TypeTraits.hpp
@@ -65,12 +65,12 @@ struct is_node_ptr<shared<T>>
 template <typename T>
 inline constexpr bool is_node_ptr_v = is_node_ptr<T>::value;
 
-template<typename T, typename... Ts>
+template <typename T, typename... Ts>
 struct all_are_node_ptrs {
-    static constexpr bool value = (is_node_ptr_v<T> && ... && is_node_ptr_v<Ts>);
+  static constexpr bool value = (is_node_ptr_v<T> && ... && is_node_ptr_v<Ts>);
 };
 
-template<typename T, typename... Ts>
+template <typename T, typename... Ts>
 inline constexpr bool all_are_node_ptrs_v = all_are_node_ptrs<T, Ts...>::value;
 
 // is_edge type trait
@@ -103,12 +103,12 @@ struct is_edge_ptr<shared<T>>
 template <typename T>
 inline constexpr bool is_edge_ptr_v = is_edge_ptr<T>::value;
 
-template<typename T, typename... Ts>
+template <typename T, typename... Ts>
 struct all_are_edge_ptrs {
-    static constexpr bool value = (is_edge_ptr_v<T> && ... && is_edge_ptr_v<Ts>);
+  static constexpr bool value = (is_edge_ptr_v<T> && ... && is_edge_ptr_v<Ts>);
 };
 
-template<typename T, typename... Ts>
+template <typename T, typename... Ts>
 inline constexpr bool all_are_edge_ptrs_v = all_are_edge_ptrs<T, Ts...>::value;
 
 }  // namespace CXXGraph

--- a/test/DijkstraTest.cpp
+++ b/test/DijkstraTest.cpp
@@ -862,8 +862,6 @@ TEST(DijkstraDeterministicTest, target_not_connected_test) {
   ASSERT_EQ(res.result, CXXGraph::INF_DOUBLE);
 }
 
-
-
 TEST(DijkstraDeterministic2Test, correct_example_1) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);

--- a/test/TypeTraitsTest.hpp
+++ b/test/TypeTraitsTest.hpp
@@ -34,6 +34,17 @@ static_assert(CXXGraph::is_node_ptr_v<const CXXGraph::Node<int>*>);
 static_assert(CXXGraph::is_node_ptr_v<shared<CXXGraph::Node<int>>>);
 static_assert(CXXGraph::is_node_ptr_v<shared<const CXXGraph::Node<int>>>);
 
+// test all_are_node_ptrs
+static_assert(CXXGraph::all_are_node_ptrs<CXXGraph::Node<int>*, CXXGraph::Node<int>*, CXXGraph::Node<int>*>::value);
+static_assert(CXXGraph::all_are_node_ptrs<const CXXGraph::Node<int>*, const CXXGraph::Node<int>*, const CXXGraph::Node<int>*>::value);
+static_assert(CXXGraph::all_are_node_ptrs<shared<CXXGraph::Node<int>>, shared<CXXGraph::Node<int>>, shared<CXXGraph::Node<int>>>::value);
+static_assert(CXXGraph::all_are_node_ptrs<shared<const CXXGraph::Node<int>>, shared<const CXXGraph::Node<int>>, shared<const CXXGraph::Node<int>>>::value);
+
+static_assert(CXXGraph::all_are_node_ptrs_v<CXXGraph::Node<int>*, CXXGraph::Node<int>*, CXXGraph::Node<int>*>);
+static_assert(CXXGraph::all_are_node_ptrs_v<const CXXGraph::Node<int>*, const CXXGraph::Node<int>*, const CXXGraph::Node<int>*>);
+static_assert(CXXGraph::all_are_node_ptrs_v<shared<CXXGraph::Node<int>>, shared<CXXGraph::Node<int>>, shared<CXXGraph::Node<int>>>);
+static_assert(CXXGraph::all_are_node_ptrs_v<shared<const CXXGraph::Node<int>>, shared<const CXXGraph::Node<int>>, shared<const CXXGraph::Node<int>>>);
+
 // test is_edge
 static_assert(CXXGraph::is_edge<CXXGraph::Edge<int>>::value);
 static_assert(CXXGraph::is_edge<CXXGraph::DirectedEdge<int>>::value);
@@ -139,6 +150,49 @@ static_assert(CXXGraph::is_edge_ptr_v<shared<const CXXGraph::DirectedEdge<int>>>
 static_assert(CXXGraph::is_edge_ptr_v<shared<const CXXGraph::DirectedWeightedEdge<int>>>);
 static_assert(CXXGraph::is_edge_ptr_v<shared<const CXXGraph::UndirectedEdge<int>>>);
 static_assert(CXXGraph::is_edge_ptr_v<shared<const CXXGraph::UndirectedWeightedEdge<int>>>);
+
+// test all_are_edge_ptrs
+static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::Edge<int>*, CXXGraph::Edge<int>*, CXXGraph::Edge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::DirectedEdge<int>*, CXXGraph::DirectedEdge<int>*, CXXGraph::DirectedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::DirectedWeightedEdge<int>*, CXXGraph::DirectedWeightedEdge<int>*, CXXGraph::DirectedWeightedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::UndirectedEdge<int>*, CXXGraph::UndirectedEdge<int>*, CXXGraph::UndirectedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::UndirectedWeightedEdge<int>*, CXXGraph::UndirectedWeightedEdge<int>*, CXXGraph::UndirectedWeightedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::Edge<int>*, const CXXGraph::Edge<int>*, const CXXGraph::Edge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::DirectedEdge<int>*, const CXXGraph::DirectedEdge<int>*, const CXXGraph::DirectedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::DirectedWeightedEdge<int>*, const CXXGraph::DirectedWeightedEdge<int>*, const CXXGraph::DirectedWeightedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::UndirectedEdge<int>*, const CXXGraph::UndirectedEdge<int>*, const CXXGraph::UndirectedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::UndirectedWeightedEdge<int>*, const CXXGraph::UndirectedWeightedEdge<int>*, const CXXGraph::UndirectedWeightedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::Edge<int>>, shared<CXXGraph::Edge<int>>, shared<CXXGraph::Edge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::DirectedEdge<int>>, shared<CXXGraph::DirectedEdge<int>>, shared<CXXGraph::DirectedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::DirectedWeightedEdge<int>>, shared<CXXGraph::DirectedWeightedEdge<int>>, shared<CXXGraph::DirectedWeightedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::UndirectedEdge<int>>, shared<CXXGraph::UndirectedEdge<int>>, shared<CXXGraph::UndirectedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::UndirectedWeightedEdge<int>>, shared<CXXGraph::UndirectedWeightedEdge<int>>, shared<CXXGraph::UndirectedWeightedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::Edge<int>>, shared<const CXXGraph::Edge<int>>, shared<const CXXGraph::Edge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::DirectedEdge<int>>, shared<const CXXGraph::DirectedEdge<int>>, shared<const CXXGraph::DirectedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::DirectedWeightedEdge<int>>, shared<const CXXGraph::DirectedWeightedEdge<int>>, shared<const CXXGraph::DirectedWeightedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::UndirectedEdge<int>>, shared<const CXXGraph::UndirectedEdge<int>>, shared<const CXXGraph::UndirectedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::UndirectedWeightedEdge<int>>, shared<const CXXGraph::UndirectedWeightedEdge<int>>, shared<const CXXGraph::UndirectedWeightedEdge<int>>>::value);
+
+static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::Edge<int>*, CXXGraph::Edge<int>*, CXXGraph::Edge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::DirectedEdge<int>*, CXXGraph::DirectedEdge<int>*, CXXGraph::DirectedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::DirectedWeightedEdge<int>*, CXXGraph::DirectedWeightedEdge<int>*, CXXGraph::DirectedWeightedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::UndirectedEdge<int>*, CXXGraph::UndirectedEdge<int>*, CXXGraph::UndirectedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::UndirectedWeightedEdge<int>*, CXXGraph::UndirectedWeightedEdge<int>*, CXXGraph::UndirectedWeightedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::Edge<int>*, const CXXGraph::Edge<int>*, const CXXGraph::Edge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::DirectedEdge<int>*, const CXXGraph::DirectedEdge<int>*, const CXXGraph::DirectedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::DirectedWeightedEdge<int>*, const CXXGraph::DirectedWeightedEdge<int>*, const CXXGraph::DirectedWeightedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::UndirectedEdge<int>*, const CXXGraph::UndirectedEdge<int>*, const CXXGraph::UndirectedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::UndirectedWeightedEdge<int>*, const CXXGraph::UndirectedWeightedEdge<int>*, const CXXGraph::UndirectedWeightedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::Edge<int>>, shared<CXXGraph::Edge<int>>, shared<CXXGraph::Edge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::DirectedEdge<int>>, shared<CXXGraph::DirectedEdge<int>>, shared<CXXGraph::DirectedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::DirectedWeightedEdge<int>>, shared<CXXGraph::DirectedWeightedEdge<int>>, shared<CXXGraph::DirectedWeightedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::UndirectedEdge<int>>, shared<CXXGraph::UndirectedEdge<int>>, shared<CXXGraph::UndirectedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::UndirectedWeightedEdge<int>>, shared<CXXGraph::UndirectedWeightedEdge<int>>, shared<CXXGraph::UndirectedWeightedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::Edge<int>>, shared<const CXXGraph::Edge<int>>, shared<const CXXGraph::Edge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::DirectedEdge<int>>, shared<const CXXGraph::DirectedEdge<int>>, shared<const CXXGraph::DirectedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::DirectedWeightedEdge<int>>, shared<const CXXGraph::DirectedWeightedEdge<int>>, shared<const CXXGraph::DirectedWeightedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::UndirectedEdge<int>>, shared<const CXXGraph::UndirectedEdge<int>>, shared<const CXXGraph::UndirectedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::UndirectedWeightedEdge<int>>, shared<const CXXGraph::UndirectedWeightedEdge<int>>, shared<const CXXGraph::UndirectedWeightedEdge<int>>>);
 
 #endif
 

--- a/test/TypeTraitsTest.hpp
+++ b/test/TypeTraitsTest.hpp
@@ -2,8 +2,9 @@
 #ifndef test_type_traits_hpp
 #define test_type_traits_hpp
 
-#include "CXXGraph/CXXGraph.hpp"
 #include <memory>
+
+#include "CXXGraph/CXXGraph.hpp"
 
 template <typename T>
 using shared = std::shared_ptr<T>;
@@ -35,15 +36,32 @@ static_assert(CXXGraph::is_node_ptr_v<shared<CXXGraph::Node<int>>>);
 static_assert(CXXGraph::is_node_ptr_v<shared<const CXXGraph::Node<int>>>);
 
 // test all_are_node_ptrs
-static_assert(CXXGraph::all_are_node_ptrs<CXXGraph::Node<int>*, CXXGraph::Node<int>*, CXXGraph::Node<int>*>::value);
-static_assert(CXXGraph::all_are_node_ptrs<const CXXGraph::Node<int>*, const CXXGraph::Node<int>*, const CXXGraph::Node<int>*>::value);
-static_assert(CXXGraph::all_are_node_ptrs<shared<CXXGraph::Node<int>>, shared<CXXGraph::Node<int>>, shared<CXXGraph::Node<int>>>::value);
-static_assert(CXXGraph::all_are_node_ptrs<shared<const CXXGraph::Node<int>>, shared<const CXXGraph::Node<int>>, shared<const CXXGraph::Node<int>>>::value);
+static_assert(
+    CXXGraph::all_are_node_ptrs<CXXGraph::Node<int>*, CXXGraph::Node<int>*,
+                                CXXGraph::Node<int>*>::value);
+static_assert(CXXGraph::all_are_node_ptrs<const CXXGraph::Node<int>*,
+                                          const CXXGraph::Node<int>*,
+                                          const CXXGraph::Node<int>*>::value);
+static_assert(CXXGraph::all_are_node_ptrs<shared<CXXGraph::Node<int>>,
+                                          shared<CXXGraph::Node<int>>,
+                                          shared<CXXGraph::Node<int>>>::value);
+static_assert(
+    CXXGraph::all_are_node_ptrs<shared<const CXXGraph::Node<int>>,
+                                shared<const CXXGraph::Node<int>>,
+                                shared<const CXXGraph::Node<int>>>::value);
 
-static_assert(CXXGraph::all_are_node_ptrs_v<CXXGraph::Node<int>*, CXXGraph::Node<int>*, CXXGraph::Node<int>*>);
-static_assert(CXXGraph::all_are_node_ptrs_v<const CXXGraph::Node<int>*, const CXXGraph::Node<int>*, const CXXGraph::Node<int>*>);
-static_assert(CXXGraph::all_are_node_ptrs_v<shared<CXXGraph::Node<int>>, shared<CXXGraph::Node<int>>, shared<CXXGraph::Node<int>>>);
-static_assert(CXXGraph::all_are_node_ptrs_v<shared<const CXXGraph::Node<int>>, shared<const CXXGraph::Node<int>>, shared<const CXXGraph::Node<int>>>);
+static_assert(
+    CXXGraph::all_are_node_ptrs_v<CXXGraph::Node<int>*, CXXGraph::Node<int>*,
+                                  CXXGraph::Node<int>*>);
+static_assert(CXXGraph::all_are_node_ptrs_v<const CXXGraph::Node<int>*,
+                                            const CXXGraph::Node<int>*,
+                                            const CXXGraph::Node<int>*>);
+static_assert(CXXGraph::all_are_node_ptrs_v<shared<CXXGraph::Node<int>>,
+                                            shared<CXXGraph::Node<int>>,
+                                            shared<CXXGraph::Node<int>>>);
+static_assert(CXXGraph::all_are_node_ptrs_v<shared<const CXXGraph::Node<int>>,
+                                            shared<const CXXGraph::Node<int>>,
+                                            shared<const CXXGraph::Node<int>>>);
 
 // test is_edge
 static_assert(CXXGraph::is_edge<CXXGraph::Edge<int>>::value);
@@ -53,29 +71,40 @@ static_assert(CXXGraph::is_edge<CXXGraph::UndirectedEdge<int>>::value);
 static_assert(CXXGraph::is_edge<CXXGraph::UndirectedWeightedEdge<int>>::value);
 static_assert(CXXGraph::is_edge<const CXXGraph::Edge<int>>::value);
 static_assert(CXXGraph::is_edge<const CXXGraph::DirectedEdge<int>>::value);
-static_assert(CXXGraph::is_edge<const CXXGraph::DirectedWeightedEdge<int>>::value);
+static_assert(
+    CXXGraph::is_edge<const CXXGraph::DirectedWeightedEdge<int>>::value);
 static_assert(CXXGraph::is_edge<const CXXGraph::UndirectedEdge<int>>::value);
-static_assert(CXXGraph::is_edge<const CXXGraph::UndirectedWeightedEdge<int>>::value);
+static_assert(
+    CXXGraph::is_edge<const CXXGraph::UndirectedWeightedEdge<int>>::value);
 static_assert(!CXXGraph::is_edge<CXXGraph::Edge<int>*>::value);
 static_assert(!CXXGraph::is_edge<CXXGraph::DirectedEdge<int>*>::value);
 static_assert(!CXXGraph::is_edge<CXXGraph::DirectedWeightedEdge<int>*>::value);
 static_assert(!CXXGraph::is_edge<CXXGraph::UndirectedEdge<int>*>::value);
-static_assert(!CXXGraph::is_edge<CXXGraph::UndirectedWeightedEdge<int>*>::value);
+static_assert(
+    !CXXGraph::is_edge<CXXGraph::UndirectedWeightedEdge<int>*>::value);
 static_assert(!CXXGraph::is_edge<const CXXGraph::Edge<int>*>::value);
 static_assert(!CXXGraph::is_edge<const CXXGraph::DirectedEdge<int>*>::value);
-static_assert(!CXXGraph::is_edge<const CXXGraph::DirectedWeightedEdge<int>*>::value);
+static_assert(
+    !CXXGraph::is_edge<const CXXGraph::DirectedWeightedEdge<int>*>::value);
 static_assert(!CXXGraph::is_edge<const CXXGraph::UndirectedEdge<int>*>::value);
-static_assert(!CXXGraph::is_edge<const CXXGraph::UndirectedWeightedEdge<int>*>::value);
+static_assert(
+    !CXXGraph::is_edge<const CXXGraph::UndirectedWeightedEdge<int>*>::value);
 static_assert(!CXXGraph::is_edge<shared<CXXGraph::Edge<int>>>::value);
 static_assert(!CXXGraph::is_edge<shared<CXXGraph::DirectedEdge<int>>>::value);
-static_assert(!CXXGraph::is_edge<shared<CXXGraph::DirectedWeightedEdge<int>>>::value);
+static_assert(
+    !CXXGraph::is_edge<shared<CXXGraph::DirectedWeightedEdge<int>>>::value);
 static_assert(!CXXGraph::is_edge<shared<CXXGraph::UndirectedEdge<int>>>::value);
-static_assert(!CXXGraph::is_edge<shared<CXXGraph::UndirectedWeightedEdge<int>>>::value);
+static_assert(
+    !CXXGraph::is_edge<shared<CXXGraph::UndirectedWeightedEdge<int>>>::value);
 static_assert(!CXXGraph::is_edge<shared<const CXXGraph::Edge<int>>>::value);
-static_assert(!CXXGraph::is_edge<shared<const CXXGraph::DirectedEdge<int>>>::value);
-static_assert(!CXXGraph::is_edge<shared<const CXXGraph::DirectedWeightedEdge<int>>>::value);
-static_assert(!CXXGraph::is_edge<shared<const CXXGraph::UndirectedEdge<int>>>::value);
-static_assert(!CXXGraph::is_edge<shared<const CXXGraph::UndirectedWeightedEdge<int>>>::value);
+static_assert(
+    !CXXGraph::is_edge<shared<const CXXGraph::DirectedEdge<int>>>::value);
+static_assert(!CXXGraph::is_edge<
+              shared<const CXXGraph::DirectedWeightedEdge<int>>>::value);
+static_assert(
+    !CXXGraph::is_edge<shared<const CXXGraph::UndirectedEdge<int>>>::value);
+static_assert(!CXXGraph::is_edge<
+              shared<const CXXGraph::UndirectedWeightedEdge<int>>>::value);
 
 static_assert(CXXGraph::is_edge_v<CXXGraph::Edge<int>>);
 static_assert(CXXGraph::is_edge_v<CXXGraph::DirectedEdge<int>>);
@@ -96,39 +125,58 @@ static_assert(!CXXGraph::is_edge_v<const CXXGraph::Edge<int>*>);
 static_assert(!CXXGraph::is_edge_v<const CXXGraph::DirectedEdge<int>*>);
 static_assert(!CXXGraph::is_edge_v<const CXXGraph::DirectedWeightedEdge<int>*>);
 static_assert(!CXXGraph::is_edge_v<const CXXGraph::UndirectedEdge<int>*>);
-static_assert(!CXXGraph::is_edge_v<const CXXGraph::UndirectedWeightedEdge<int>*>);
+static_assert(
+    !CXXGraph::is_edge_v<const CXXGraph::UndirectedWeightedEdge<int>*>);
 static_assert(!CXXGraph::is_edge_v<shared<CXXGraph::Edge<int>>>);
 static_assert(!CXXGraph::is_edge_v<shared<CXXGraph::DirectedEdge<int>>>);
-static_assert(!CXXGraph::is_edge_v<shared<CXXGraph::DirectedWeightedEdge<int>>>);
+static_assert(
+    !CXXGraph::is_edge_v<shared<CXXGraph::DirectedWeightedEdge<int>>>);
 static_assert(!CXXGraph::is_edge_v<shared<CXXGraph::UndirectedEdge<int>>>);
-static_assert(!CXXGraph::is_edge_v<shared<CXXGraph::UndirectedWeightedEdge<int>>>);
+static_assert(
+    !CXXGraph::is_edge_v<shared<CXXGraph::UndirectedWeightedEdge<int>>>);
 static_assert(!CXXGraph::is_edge_v<shared<const CXXGraph::Edge<int>>>);
 static_assert(!CXXGraph::is_edge_v<shared<const CXXGraph::DirectedEdge<int>>>);
-static_assert(!CXXGraph::is_edge_v<shared<const CXXGraph::DirectedWeightedEdge<int>>>);
-static_assert(!CXXGraph::is_edge_v<shared<const CXXGraph::UndirectedEdge<int>>>);
-static_assert(!CXXGraph::is_edge_v<shared<const CXXGraph::UndirectedWeightedEdge<int>>>);
+static_assert(
+    !CXXGraph::is_edge_v<shared<const CXXGraph::DirectedWeightedEdge<int>>>);
+static_assert(
+    !CXXGraph::is_edge_v<shared<const CXXGraph::UndirectedEdge<int>>>);
+static_assert(
+    !CXXGraph::is_edge_v<shared<const CXXGraph::UndirectedWeightedEdge<int>>>);
 
 // test is_edge_ptr
 static_assert(CXXGraph::is_edge_ptr<CXXGraph::Edge<int>*>::value);
 static_assert(CXXGraph::is_edge_ptr<CXXGraph::DirectedEdge<int>*>::value);
-static_assert(CXXGraph::is_edge_ptr<CXXGraph::DirectedWeightedEdge<int>*>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<CXXGraph::DirectedWeightedEdge<int>*>::value);
 static_assert(CXXGraph::is_edge_ptr<CXXGraph::UndirectedEdge<int>*>::value);
-static_assert(CXXGraph::is_edge_ptr<CXXGraph::UndirectedWeightedEdge<int>*>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<CXXGraph::UndirectedWeightedEdge<int>*>::value);
 static_assert(CXXGraph::is_edge_ptr<const CXXGraph::Edge<int>*>::value);
 static_assert(CXXGraph::is_edge_ptr<const CXXGraph::DirectedEdge<int>*>::value);
-static_assert(CXXGraph::is_edge_ptr<const CXXGraph::DirectedWeightedEdge<int>*>::value);
-static_assert(CXXGraph::is_edge_ptr<const CXXGraph::UndirectedEdge<int>*>::value);
-static_assert(CXXGraph::is_edge_ptr<const CXXGraph::UndirectedWeightedEdge<int>*>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<const CXXGraph::DirectedWeightedEdge<int>*>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<const CXXGraph::UndirectedEdge<int>*>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<const CXXGraph::UndirectedWeightedEdge<int>*>::value);
 static_assert(CXXGraph::is_edge_ptr<shared<CXXGraph::Edge<int>>>::value);
-static_assert(CXXGraph::is_edge_ptr<shared<CXXGraph::DirectedEdge<int>>>::value);
-static_assert(CXXGraph::is_edge_ptr<shared<CXXGraph::DirectedWeightedEdge<int>>>::value);
-static_assert(CXXGraph::is_edge_ptr<shared<CXXGraph::UndirectedEdge<int>>>::value);
-static_assert(CXXGraph::is_edge_ptr<shared<CXXGraph::UndirectedWeightedEdge<int>>>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<shared<CXXGraph::DirectedEdge<int>>>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<shared<CXXGraph::DirectedWeightedEdge<int>>>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<shared<CXXGraph::UndirectedEdge<int>>>::value);
+static_assert(CXXGraph::is_edge_ptr<
+              shared<CXXGraph::UndirectedWeightedEdge<int>>>::value);
 static_assert(CXXGraph::is_edge_ptr<shared<const CXXGraph::Edge<int>>>::value);
-static_assert(CXXGraph::is_edge_ptr<shared<const CXXGraph::DirectedEdge<int>>>::value);
-static_assert(CXXGraph::is_edge_ptr<shared<const CXXGraph::DirectedWeightedEdge<int>>>::value);
-static_assert(CXXGraph::is_edge_ptr<shared<const CXXGraph::UndirectedEdge<int>>>::value);
-static_assert(CXXGraph::is_edge_ptr<shared<const CXXGraph::UndirectedWeightedEdge<int>>>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<shared<const CXXGraph::DirectedEdge<int>>>::value);
+static_assert(CXXGraph::is_edge_ptr<
+              shared<const CXXGraph::DirectedWeightedEdge<int>>>::value);
+static_assert(
+    CXXGraph::is_edge_ptr<shared<const CXXGraph::UndirectedEdge<int>>>::value);
+static_assert(CXXGraph::is_edge_ptr<
+              shared<const CXXGraph::UndirectedWeightedEdge<int>>>::value);
 
 static_assert(CXXGraph::is_edge_ptr_v<CXXGraph::Edge<int>*>);
 static_assert(CXXGraph::is_edge_ptr_v<CXXGraph::DirectedEdge<int>*>);
@@ -137,62 +185,178 @@ static_assert(CXXGraph::is_edge_ptr_v<CXXGraph::UndirectedEdge<int>*>);
 static_assert(CXXGraph::is_edge_ptr_v<CXXGraph::UndirectedWeightedEdge<int>*>);
 static_assert(CXXGraph::is_edge_ptr_v<const CXXGraph::Edge<int>*>);
 static_assert(CXXGraph::is_edge_ptr_v<const CXXGraph::DirectedEdge<int>*>);
-static_assert(CXXGraph::is_edge_ptr_v<const CXXGraph::DirectedWeightedEdge<int>*>);
+static_assert(
+    CXXGraph::is_edge_ptr_v<const CXXGraph::DirectedWeightedEdge<int>*>);
 static_assert(CXXGraph::is_edge_ptr_v<const CXXGraph::UndirectedEdge<int>*>);
-static_assert(CXXGraph::is_edge_ptr_v<const CXXGraph::UndirectedWeightedEdge<int>*>);
+static_assert(
+    CXXGraph::is_edge_ptr_v<const CXXGraph::UndirectedWeightedEdge<int>*>);
 static_assert(CXXGraph::is_edge_ptr_v<shared<CXXGraph::Edge<int>>>);
 static_assert(CXXGraph::is_edge_ptr_v<shared<CXXGraph::DirectedEdge<int>>>);
-static_assert(CXXGraph::is_edge_ptr_v<shared<CXXGraph::DirectedWeightedEdge<int>>>);
+static_assert(
+    CXXGraph::is_edge_ptr_v<shared<CXXGraph::DirectedWeightedEdge<int>>>);
 static_assert(CXXGraph::is_edge_ptr_v<shared<CXXGraph::UndirectedEdge<int>>>);
-static_assert(CXXGraph::is_edge_ptr_v<shared<CXXGraph::UndirectedWeightedEdge<int>>>);
+static_assert(
+    CXXGraph::is_edge_ptr_v<shared<CXXGraph::UndirectedWeightedEdge<int>>>);
 static_assert(CXXGraph::is_edge_ptr_v<shared<const CXXGraph::Edge<int>>>);
-static_assert(CXXGraph::is_edge_ptr_v<shared<const CXXGraph::DirectedEdge<int>>>);
-static_assert(CXXGraph::is_edge_ptr_v<shared<const CXXGraph::DirectedWeightedEdge<int>>>);
-static_assert(CXXGraph::is_edge_ptr_v<shared<const CXXGraph::UndirectedEdge<int>>>);
-static_assert(CXXGraph::is_edge_ptr_v<shared<const CXXGraph::UndirectedWeightedEdge<int>>>);
+static_assert(
+    CXXGraph::is_edge_ptr_v<shared<const CXXGraph::DirectedEdge<int>>>);
+static_assert(
+    CXXGraph::is_edge_ptr_v<shared<const CXXGraph::DirectedWeightedEdge<int>>>);
+static_assert(
+    CXXGraph::is_edge_ptr_v<shared<const CXXGraph::UndirectedEdge<int>>>);
+static_assert(CXXGraph::is_edge_ptr_v<
+              shared<const CXXGraph::UndirectedWeightedEdge<int>>>);
 
 // test all_are_edge_ptrs
-static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::Edge<int>*, CXXGraph::Edge<int>*, CXXGraph::Edge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::DirectedEdge<int>*, CXXGraph::DirectedEdge<int>*, CXXGraph::DirectedEdge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::DirectedWeightedEdge<int>*, CXXGraph::DirectedWeightedEdge<int>*, CXXGraph::DirectedWeightedEdge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::UndirectedEdge<int>*, CXXGraph::UndirectedEdge<int>*, CXXGraph::UndirectedEdge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::UndirectedWeightedEdge<int>*, CXXGraph::UndirectedWeightedEdge<int>*, CXXGraph::UndirectedWeightedEdge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::Edge<int>*, const CXXGraph::Edge<int>*, const CXXGraph::Edge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::DirectedEdge<int>*, const CXXGraph::DirectedEdge<int>*, const CXXGraph::DirectedEdge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::DirectedWeightedEdge<int>*, const CXXGraph::DirectedWeightedEdge<int>*, const CXXGraph::DirectedWeightedEdge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::UndirectedEdge<int>*, const CXXGraph::UndirectedEdge<int>*, const CXXGraph::UndirectedEdge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::UndirectedWeightedEdge<int>*, const CXXGraph::UndirectedWeightedEdge<int>*, const CXXGraph::UndirectedWeightedEdge<int>*>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::Edge<int>>, shared<CXXGraph::Edge<int>>, shared<CXXGraph::Edge<int>>>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::DirectedEdge<int>>, shared<CXXGraph::DirectedEdge<int>>, shared<CXXGraph::DirectedEdge<int>>>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::DirectedWeightedEdge<int>>, shared<CXXGraph::DirectedWeightedEdge<int>>, shared<CXXGraph::DirectedWeightedEdge<int>>>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::UndirectedEdge<int>>, shared<CXXGraph::UndirectedEdge<int>>, shared<CXXGraph::UndirectedEdge<int>>>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::UndirectedWeightedEdge<int>>, shared<CXXGraph::UndirectedWeightedEdge<int>>, shared<CXXGraph::UndirectedWeightedEdge<int>>>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::Edge<int>>, shared<const CXXGraph::Edge<int>>, shared<const CXXGraph::Edge<int>>>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::DirectedEdge<int>>, shared<const CXXGraph::DirectedEdge<int>>, shared<const CXXGraph::DirectedEdge<int>>>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::DirectedWeightedEdge<int>>, shared<const CXXGraph::DirectedWeightedEdge<int>>, shared<const CXXGraph::DirectedWeightedEdge<int>>>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::UndirectedEdge<int>>, shared<const CXXGraph::UndirectedEdge<int>>, shared<const CXXGraph::UndirectedEdge<int>>>::value);
-static_assert(CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::UndirectedWeightedEdge<int>>, shared<const CXXGraph::UndirectedWeightedEdge<int>>, shared<const CXXGraph::UndirectedWeightedEdge<int>>>::value);
+static_assert(
+    CXXGraph::all_are_edge_ptrs<CXXGraph::Edge<int>*, CXXGraph::Edge<int>*,
+                                CXXGraph::Edge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<CXXGraph::DirectedEdge<int>*,
+                                          CXXGraph::DirectedEdge<int>*,
+                                          CXXGraph::DirectedEdge<int>*>::value);
+static_assert(
+    CXXGraph::all_are_edge_ptrs<CXXGraph::DirectedWeightedEdge<int>*,
+                                CXXGraph::DirectedWeightedEdge<int>*,
+                                CXXGraph::DirectedWeightedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<
+              CXXGraph::UndirectedEdge<int>*, CXXGraph::UndirectedEdge<int>*,
+              CXXGraph::UndirectedEdge<int>*>::value);
+static_assert(
+    CXXGraph::all_are_edge_ptrs<CXXGraph::UndirectedWeightedEdge<int>*,
+                                CXXGraph::UndirectedWeightedEdge<int>*,
+                                CXXGraph::UndirectedWeightedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<const CXXGraph::Edge<int>*,
+                                          const CXXGraph::Edge<int>*,
+                                          const CXXGraph::Edge<int>*>::value);
+static_assert(
+    CXXGraph::all_are_edge_ptrs<const CXXGraph::DirectedEdge<int>*,
+                                const CXXGraph::DirectedEdge<int>*,
+                                const CXXGraph::DirectedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<
+              const CXXGraph::DirectedWeightedEdge<int>*,
+              const CXXGraph::DirectedWeightedEdge<int>*,
+              const CXXGraph::DirectedWeightedEdge<int>*>::value);
+static_assert(
+    CXXGraph::all_are_edge_ptrs<const CXXGraph::UndirectedEdge<int>*,
+                                const CXXGraph::UndirectedEdge<int>*,
+                                const CXXGraph::UndirectedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<
+              const CXXGraph::UndirectedWeightedEdge<int>*,
+              const CXXGraph::UndirectedWeightedEdge<int>*,
+              const CXXGraph::UndirectedWeightedEdge<int>*>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<shared<CXXGraph::Edge<int>>,
+                                          shared<CXXGraph::Edge<int>>,
+                                          shared<CXXGraph::Edge<int>>>::value);
+static_assert(
+    CXXGraph::all_are_edge_ptrs<shared<CXXGraph::DirectedEdge<int>>,
+                                shared<CXXGraph::DirectedEdge<int>>,
+                                shared<CXXGraph::DirectedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<
+              shared<CXXGraph::DirectedWeightedEdge<int>>,
+              shared<CXXGraph::DirectedWeightedEdge<int>>,
+              shared<CXXGraph::DirectedWeightedEdge<int>>>::value);
+static_assert(
+    CXXGraph::all_are_edge_ptrs<shared<CXXGraph::UndirectedEdge<int>>,
+                                shared<CXXGraph::UndirectedEdge<int>>,
+                                shared<CXXGraph::UndirectedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<
+              shared<CXXGraph::UndirectedWeightedEdge<int>>,
+              shared<CXXGraph::UndirectedWeightedEdge<int>>,
+              shared<CXXGraph::UndirectedWeightedEdge<int>>>::value);
+static_assert(
+    CXXGraph::all_are_edge_ptrs<shared<const CXXGraph::Edge<int>>,
+                                shared<const CXXGraph::Edge<int>>,
+                                shared<const CXXGraph::Edge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<
+              shared<const CXXGraph::DirectedEdge<int>>,
+              shared<const CXXGraph::DirectedEdge<int>>,
+              shared<const CXXGraph::DirectedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<
+              shared<const CXXGraph::DirectedWeightedEdge<int>>,
+              shared<const CXXGraph::DirectedWeightedEdge<int>>,
+              shared<const CXXGraph::DirectedWeightedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<
+              shared<const CXXGraph::UndirectedEdge<int>>,
+              shared<const CXXGraph::UndirectedEdge<int>>,
+              shared<const CXXGraph::UndirectedEdge<int>>>::value);
+static_assert(CXXGraph::all_are_edge_ptrs<
+              shared<const CXXGraph::UndirectedWeightedEdge<int>>,
+              shared<const CXXGraph::UndirectedWeightedEdge<int>>,
+              shared<const CXXGraph::UndirectedWeightedEdge<int>>>::value);
 
-static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::Edge<int>*, CXXGraph::Edge<int>*, CXXGraph::Edge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::DirectedEdge<int>*, CXXGraph::DirectedEdge<int>*, CXXGraph::DirectedEdge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::DirectedWeightedEdge<int>*, CXXGraph::DirectedWeightedEdge<int>*, CXXGraph::DirectedWeightedEdge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::UndirectedEdge<int>*, CXXGraph::UndirectedEdge<int>*, CXXGraph::UndirectedEdge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::UndirectedWeightedEdge<int>*, CXXGraph::UndirectedWeightedEdge<int>*, CXXGraph::UndirectedWeightedEdge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::Edge<int>*, const CXXGraph::Edge<int>*, const CXXGraph::Edge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::DirectedEdge<int>*, const CXXGraph::DirectedEdge<int>*, const CXXGraph::DirectedEdge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::DirectedWeightedEdge<int>*, const CXXGraph::DirectedWeightedEdge<int>*, const CXXGraph::DirectedWeightedEdge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::UndirectedEdge<int>*, const CXXGraph::UndirectedEdge<int>*, const CXXGraph::UndirectedEdge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::UndirectedWeightedEdge<int>*, const CXXGraph::UndirectedWeightedEdge<int>*, const CXXGraph::UndirectedWeightedEdge<int>*>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::Edge<int>>, shared<CXXGraph::Edge<int>>, shared<CXXGraph::Edge<int>>>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::DirectedEdge<int>>, shared<CXXGraph::DirectedEdge<int>>, shared<CXXGraph::DirectedEdge<int>>>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::DirectedWeightedEdge<int>>, shared<CXXGraph::DirectedWeightedEdge<int>>, shared<CXXGraph::DirectedWeightedEdge<int>>>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::UndirectedEdge<int>>, shared<CXXGraph::UndirectedEdge<int>>, shared<CXXGraph::UndirectedEdge<int>>>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::UndirectedWeightedEdge<int>>, shared<CXXGraph::UndirectedWeightedEdge<int>>, shared<CXXGraph::UndirectedWeightedEdge<int>>>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::Edge<int>>, shared<const CXXGraph::Edge<int>>, shared<const CXXGraph::Edge<int>>>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::DirectedEdge<int>>, shared<const CXXGraph::DirectedEdge<int>>, shared<const CXXGraph::DirectedEdge<int>>>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::DirectedWeightedEdge<int>>, shared<const CXXGraph::DirectedWeightedEdge<int>>, shared<const CXXGraph::DirectedWeightedEdge<int>>>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::UndirectedEdge<int>>, shared<const CXXGraph::UndirectedEdge<int>>, shared<const CXXGraph::UndirectedEdge<int>>>);
-static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::UndirectedWeightedEdge<int>>, shared<const CXXGraph::UndirectedWeightedEdge<int>>, shared<const CXXGraph::UndirectedWeightedEdge<int>>>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<CXXGraph::Edge<int>*, CXXGraph::Edge<int>*,
+                                  CXXGraph::Edge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::DirectedEdge<int>*,
+                                            CXXGraph::DirectedEdge<int>*,
+                                            CXXGraph::DirectedEdge<int>*>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<CXXGraph::DirectedWeightedEdge<int>*,
+                                  CXXGraph::DirectedWeightedEdge<int>*,
+                                  CXXGraph::DirectedWeightedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<CXXGraph::UndirectedEdge<int>*,
+                                            CXXGraph::UndirectedEdge<int>*,
+                                            CXXGraph::UndirectedEdge<int>*>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<CXXGraph::UndirectedWeightedEdge<int>*,
+                                  CXXGraph::UndirectedWeightedEdge<int>*,
+                                  CXXGraph::UndirectedWeightedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<const CXXGraph::Edge<int>*,
+                                            const CXXGraph::Edge<int>*,
+                                            const CXXGraph::Edge<int>*>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<const CXXGraph::DirectedEdge<int>*,
+                                  const CXXGraph::DirectedEdge<int>*,
+                                  const CXXGraph::DirectedEdge<int>*>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<const CXXGraph::DirectedWeightedEdge<int>*,
+                                  const CXXGraph::DirectedWeightedEdge<int>*,
+                                  const CXXGraph::DirectedWeightedEdge<int>*>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<const CXXGraph::UndirectedEdge<int>*,
+                                  const CXXGraph::UndirectedEdge<int>*,
+                                  const CXXGraph::UndirectedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<
+              const CXXGraph::UndirectedWeightedEdge<int>*,
+              const CXXGraph::UndirectedWeightedEdge<int>*,
+              const CXXGraph::UndirectedWeightedEdge<int>*>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::Edge<int>>,
+                                            shared<CXXGraph::Edge<int>>,
+                                            shared<CXXGraph::Edge<int>>>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::DirectedEdge<int>>,
+                                  shared<CXXGraph::DirectedEdge<int>>,
+                                  shared<CXXGraph::DirectedEdge<int>>>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::DirectedWeightedEdge<int>>,
+                                  shared<CXXGraph::DirectedWeightedEdge<int>>,
+                                  shared<CXXGraph::DirectedWeightedEdge<int>>>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<shared<CXXGraph::UndirectedEdge<int>>,
+                                  shared<CXXGraph::UndirectedEdge<int>>,
+                                  shared<CXXGraph::UndirectedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<
+              shared<CXXGraph::UndirectedWeightedEdge<int>>,
+              shared<CXXGraph::UndirectedWeightedEdge<int>>,
+              shared<CXXGraph::UndirectedWeightedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::Edge<int>>,
+                                            shared<const CXXGraph::Edge<int>>,
+                                            shared<const CXXGraph::Edge<int>>>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::DirectedEdge<int>>,
+                                  shared<const CXXGraph::DirectedEdge<int>>,
+                                  shared<const CXXGraph::DirectedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<
+              shared<const CXXGraph::DirectedWeightedEdge<int>>,
+              shared<const CXXGraph::DirectedWeightedEdge<int>>,
+              shared<const CXXGraph::DirectedWeightedEdge<int>>>);
+static_assert(
+    CXXGraph::all_are_edge_ptrs_v<shared<const CXXGraph::UndirectedEdge<int>>,
+                                  shared<const CXXGraph::UndirectedEdge<int>>,
+                                  shared<const CXXGraph::UndirectedEdge<int>>>);
+static_assert(CXXGraph::all_are_edge_ptrs_v<
+              shared<const CXXGraph::UndirectedWeightedEdge<int>>,
+              shared<const CXXGraph::UndirectedWeightedEdge<int>>,
+              shared<const CXXGraph::UndirectedWeightedEdge<int>>>);
 
 #endif
-

--- a/test/welshPowellColoringTest.cpp
+++ b/test/welshPowellColoringTest.cpp
@@ -5,21 +5,23 @@ TEST(welshPowellColoring, one_edge_two_nodes_undirected) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);
 
-  CXXGraph::UndirectedWeightedEdge<int> edge12(3, node1, node2,4);
+  CXXGraph::UndirectedWeightedEdge<int> edge12(3, node1, node2, 4);
 
   CXXGraph::T_EdgeSet<int> edgeSet;
-  edgeSet.insert(std::make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge12));
+  edgeSet.insert(
+      std::make_shared<CXXGraph::UndirectedWeightedEdge<int>>(edge12));
 
   CXXGraph::Graph<int> graph(edgeSet);
 
   auto result = graph.welshPowellColoring();
 
   // get the highest coloring order
-  auto highest_coloring_order = std::max_element(result.begin(), result.end(),
-                                     [](const auto& lhs, const auto& rhs) {
-                                       return lhs.second < rhs.second;
-                                     }
-  )->second;
+  auto highest_coloring_order =
+      std::max_element(result.begin(), result.end(),
+                       [](const auto& lhs, const auto& rhs) {
+                         return lhs.second < rhs.second;
+                       })
+          ->second;
   ASSERT_EQ(graph.isUndirectedGraph(), true);
 
   // Asserts that the chromatic color of the graph is 2
@@ -40,75 +42,53 @@ TEST(welshPowellColoring, undirected_simon_james) {
   CXXGraph::Node<int> nodeJ("j", 1);
   CXXGraph::Node<int> nodeK("k", 1);
 
-
   CXXGraph::UndirectedEdge<int> edgeAB(1, nodeA, nodeB),
-      edgeBA(1, nodeB, nodeA), //
+      edgeBA(1, nodeB, nodeA),  //
 
-      edgeAC(1, nodeA, nodeC),
-      edgeCA(1, nodeC, nodeA), //
+      edgeAC(1, nodeA, nodeC), edgeCA(1, nodeC, nodeA),  //
 
-      edgeAD(1, nodeA, nodeD),
-      edgeDA(1, nodeD, nodeA), //
+      edgeAD(1, nodeA, nodeD), edgeDA(1, nodeD, nodeA),  //
 
-      edgeAK(1, nodeA, nodeK),
-      edgeKA(1, nodeK, nodeA),
+      edgeAK(1, nodeA, nodeK), edgeKA(1, nodeK, nodeA),
 
-      edgeAH(1, nodeA, nodeH),
-      edgeHA(1, nodeA, nodeH), //
+      edgeAH(1, nodeA, nodeH), edgeHA(1, nodeA, nodeH),  //
 
-      edgeAE(1, nodeA, nodeE),
-      edgeEA(1, nodeA, nodeH), //
+      edgeAE(1, nodeA, nodeE), edgeEA(1, nodeA, nodeH),  //
 
-      edgeAG(1, nodeA, nodeG),
-      edgeGA(1, nodeA, nodeG), //
+      edgeAG(1, nodeA, nodeG), edgeGA(1, nodeA, nodeG),  //
 
-      edgeBK(1, nodeB, nodeK),
-      edgeKB(1, nodeK, nodeB), //
+      edgeBK(1, nodeB, nodeK), edgeKB(1, nodeK, nodeB),  //
 
-      edgeBI(1, nodeB, nodeI),
-      edgeIB(1, nodeI, nodeB), //
+      edgeBI(1, nodeB, nodeI), edgeIB(1, nodeI, nodeB),  //
 
-      edgeBJ(1, nodeB, nodeJ),
-      edgeJB(1, nodeJ, nodeB),
+      edgeBJ(1, nodeB, nodeJ), edgeJB(1, nodeJ, nodeB),
 
-      edgeBF(1, nodeB, nodeF),
-      edgeFB(1, nodeF, nodeB), //
+      edgeBF(1, nodeB, nodeF), edgeFB(1, nodeF, nodeB),  //
 
-      edgeBD(1, nodeB, nodeD),
-      edgeDB(1, nodeD, nodeB), //
+      edgeBD(1, nodeB, nodeD), edgeDB(1, nodeD, nodeB),  //
 
-      edgeCE(1, nodeC, nodeE),
-      edgeEC(1, nodeE, nodeC), //
+      edgeCE(1, nodeC, nodeE), edgeEC(1, nodeE, nodeC),  //
 
-      edgeCD(1, nodeC, nodeD),
-      edgeDC(1, nodeD, nodeC), //
+      edgeCD(1, nodeC, nodeD), edgeDC(1, nodeD, nodeC),  //
 
-      edgeCH(1, nodeC, nodeH),
-      edgeHC(1, nodeH, nodeC), //
+      edgeCH(1, nodeC, nodeH), edgeHC(1, nodeH, nodeC),  //
 
-      edgeCG(1, nodeC, nodeG),
-      edgeGC(1, nodeG, nodeC), //
+      edgeCG(1, nodeC, nodeG), edgeGC(1, nodeG, nodeC),  //
 
-      edgeDE(1, nodeD, nodeE),
-      edgeED(1, nodeD, nodeE), //
+      edgeDE(1, nodeD, nodeE), edgeED(1, nodeD, nodeE),  //
 
-      edgeEK(1, nodeE, nodeK),
-      edgeKE(1, nodeK, nodeE), //
+      edgeEK(1, nodeE, nodeK), edgeKE(1, nodeK, nodeE),  //
 
-      edgeFI(1, nodeF, nodeI),
-      edgeIF(1, nodeI, nodeF),
+      edgeFI(1, nodeF, nodeI), edgeIF(1, nodeI, nodeF),
 
-      edgeFJ(1, nodeF, nodeJ),
-      edgeJF(1, nodeJ, nodeF),
+      edgeFJ(1, nodeF, nodeJ), edgeJF(1, nodeJ, nodeF),
 
-      edgeFG(1, nodeF, nodeG),
-      edgeGF(1, nodeG, nodeF),
+      edgeFG(1, nodeF, nodeG), edgeGF(1, nodeG, nodeF),
 
-      edgeGH(1, nodeG, nodeH),
-      edgeHG(1, nodeH, nodeG),
+      edgeGH(1, nodeG, nodeH), edgeHG(1, nodeH, nodeG),
 
-      edgeIJ(1, nodeI, nodeJ), //
-      edgeJI(1, nodeJ, nodeI); //
+      edgeIJ(1, nodeI, nodeJ),  //
+      edgeJI(1, nodeJ, nodeI);  //
 
   CXXGraph::T_EdgeSet<int> edgeSet;
 
@@ -158,17 +138,18 @@ TEST(welshPowellColoring, undirected_simon_james) {
 
   edgeSet.insert(std::make_shared<CXXGraph::UndirectedEdge<int>>(edgeIJ));
 
-
   CXXGraph::Graph<int> graph(edgeSet);
 
   auto result = graph.welshPowellColoring();
-  auto highest_coloring_order = std::max_element(result.begin(), result.end(),
-                                                 [](const auto& lhs, const auto& rhs) {
-                                                   return lhs.second < rhs.second;
-                                                 }
-  )->second;
+  auto highest_coloring_order =
+      std::max_element(result.begin(), result.end(),
+                       [](const auto& lhs, const auto& rhs) {
+                         return lhs.second < rhs.second;
+                       })
+          ->second;
 
   ASSERT_EQ(graph.isUndirectedGraph(), true);
-  // Asserts that the chromatic color of the graph is 4, as indicated in 2:30 of video
+  // Asserts that the chromatic color of the graph is 4, as indicated in 2:30 of
+  // video
   ASSERT_EQ(highest_coloring_order, 4);
 }


### PR DESCRIPTION
This is addressed by adding workaround type traits into `TypeTraits.hpp`:

```
template<typename T, typename... Ts>
struct all_are_node_ptrs {
    static constexpr bool value = (is_node_ptr_v<T> && ... && is_node_ptr_v<Ts>);
};

template<typename T, typename... Ts>
inline constexpr bool all_are_node_ptrs_v = all_are_node_ptrs<T, Ts...>::value;
```

and

```
template<typename T, typename... Ts>
struct all_are_edge_ptrs {
    static constexpr bool value = (is_edge_ptr_v<T> && ... && is_edge_ptr_v<Ts>);
};

template<typename T, typename... Ts>
inline constexpr bool all_are_edge_ptrs_v = all_are_edge_ptrs<T, Ts...>::value;
```


I've also cleaned-up warnings on Windows that were caused by not explicitly typecasting.
