### PR TITLE
include <algorithm> for gcc 14 compilation errors

### DIFF
--- a/include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp
@@ -27,6 +27,7 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <algorithm>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/CycleDetection_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/CycleDetection_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/Dial_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dial_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Graph_decl.h
+++ b/include/CXXGraph/Graph/Graph_decl.h
@@ -35,7 +35,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
-#include <algorithm>
 
 #include "CXXGraph/Edge/DirectedEdge.h"
 #include "CXXGraph/Edge/DirectedWeightedEdge.h"

--- a/include/CXXGraph/Graph/Graph_decl.h
+++ b/include/CXXGraph/Graph/Graph_decl.h
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <algorithm>
 
 #include "CXXGraph/Edge/DirectedEdge.h"
 #include "CXXGraph/Edge/DirectedWeightedEdge.h"

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <deque>
+#include <algorithm>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 #include "CXXGraph/Utility/ConstString.hpp"


### PR DESCRIPTION
I met a lot of compilation errors on gcc 14:
It seems to be caused by a lack of including <algorithm> header.
This PR is fixed this problem.

Please review it.

<details>
<summary>CXXGraph 3.1.0 compilation errors on gcc 14</summary>

In file included from include/CXXGraph/Graph/Graph.h:23,
                 from include/CXXGraph/CXXGraph.hpp:11,
                 from test_package.cpp:3:
include/CXXGraph/Graph/Graph_impl.hpp: In member function ‘virtual void CXXGraph::Graph<T>::setNodeData(const std::string&, T)’:
include/CXXGraph/Graph/Graph_impl.hpp:316:22: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  316 |   auto nodeIt = std::find_if(
      |                      ^~~~~~~
      |                      find
include/CXXGraph/Graph/Graph_impl.hpp: In member function ‘virtual std::shared_ptr<std::vector<CXXGraph::Node<T> > > CXXGraph::Graph<T>::eulerianPath() const’:
include/CXXGraph/Graph/Graph_impl.hpp:465:27: error: ‘max_element’ is not a member of ‘std’; did you mean ‘tuple_element’?
  465 |   auto firstNodeIt = std::max_element(
      |                           ^~~~~~~~~~~
      |                           tuple_element
include/CXXGraph/Graph/Graph_impl.hpp: In member function ‘virtual const std::vector<CXXGraph::Node<T> > CXXGraph::Graph<T>::graph_slicing(const CXXGraph::Node<T>&) const’:
include/CXXGraph/Graph/Graph_impl.hpp:775:29: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  775 |   auto start_node_it = std::find_if(
      |                             ^~~~~~~
      |                             find
include/CXXGraph/Graph/Graph_impl.hpp:785:14: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  785 |     if (std::find_if(C.begin(), C.end(), [node](const Node<T> nodeC) {
      |              ^~~~~~~
      |              find
include/CXXGraph/Graph/Graph_impl.hpp:800:14: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  800 |     if (std::find_if(M.begin(), M.end(), [nodeC](const Node<T> nodeM) {
      |              ^~~~~~~
      |              find
In file included from include/CXXGraph/Graph/Graph.h:26:
include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp: In member function ‘virtual const CXXGraph::BellmanFordResult CXXGraph::Graph<T>::bellmanford(const CXXGraph::Node<T>&, const CXXGraph::Node<T>&) const’:
include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp:36:30: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   36 |   auto source_node_it = std::find_if(
      |                              ^~~~~~~
      |                              find
include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp:44:30: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   44 |   auto target_node_it = std::find_if(
      |                              ^~~~~~~
      |                              find
In file included from include/CXXGraph/Graph/Graph.h:27:
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp: In member function ‘virtual CXXGraph::BestFirstSearchResult<T> CXXGraph::Graph<T>::best_first_search(const CXXGraph::Node<T>&, const CXXGraph::Node<T>&) const’:
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:40:30: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   40 |   auto source_node_it = std::find_if(
      |                              ^~~~~~~
      |                              find
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:48:30: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   48 |   auto target_node_it = std::find_if(
      |                              ^~~~~~~
      |                              find
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp: In member function ‘virtual const std::vector<CXXGraph::Node<T> > CXXGraph::Graph<T>::concurrency_breadth_first_search(const CXXGraph::Node<T>&, size_t) const’:
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:111:29: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  111 |   auto start_node_it = std::find_if(
      |                             ^~~~~~~
      |                             find
In file included from include/CXXGraph/Graph/Graph.h:29:
include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp: In member function ‘virtual const std::vector<CXXGraph::Node<T> > CXXGraph::Graph<T>::breadth_first_search(const CXXGraph::Node<T>&) const’:
include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp:36:29: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   36 |   auto start_node_it = std::find_if(
      |                             ^~~~~~~
      |                             find
In file included from include/CXXGraph/Graph/Graph.h:31:
include/CXXGraph/Graph/Algorithm/CycleDetection_impl.hpp: In member function ‘virtual bool CXXGraph::Graph<T>::containsCycle(CXXGraph::T_EdgeSet<T>*) const’:
include/CXXGraph/Graph/Algorithm/CycleDetection_impl.hpp:122:16: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  122 |       if (std::find_if((*subset).begin(), (*subset).end(), nodeExists) ==
      |                ^~~~~~~
      |                find
include/CXXGraph/Graph/Algorithm/CycleDetection_impl.hpp: In member function ‘virtual bool CXXGraph::Graph<T>::containsCycle(CXXGraph::shared<const std::unordered_set<std::shared_ptr<const CXXGraph::Edge<T> >, CXXGraph::edgeHash<T> > >) const’:
include/CXXGraph/Graph/Algorithm/CycleDetection_impl.hpp:148:16: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  148 |       if (std::find_if((*subset).begin(), (*subset).end(), nodeExists) ==
      |                ^~~~~~~
      |                find
In file included from include/CXXGraph/Graph/Graph.h:32:
include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp: In member function ‘virtual const std::vector<CXXGraph::Node<T> > CXXGraph::Graph<T>::depth_first_search(const CXXGraph::Node<T>&) const’:
include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp:36:29: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   36 |   auto start_node_it = std::find_if(
      |                             ^~~~~~~
      |                             find
In file included from include/CXXGraph/Graph/Graph.h:33:
include/CXXGraph/Graph/Algorithm/Dial_impl.hpp: In member function ‘virtual const CXXGraph::DialResult CXXGraph::Graph<T>::dial(const CXXGraph::Node<T>&, int) const’:
include/CXXGraph/Graph/Algorithm/Dial_impl.hpp:36:30: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   36 |   auto source_node_it = std::find_if(
      |                              ^~~~~~~
      |                              find
include/CXXGraph/Graph/Algorithm/Dial_impl.hpp:112:23: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  112 |       auto u_i = std::find_if(
      |                       ^~~~~~~
      |                       find
include/CXXGraph/Graph/Algorithm/Dial_impl.hpp:119:23: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
  119 |       auto v_i = std::find_if(
      |                       ^~~~~~~
      |                       find
In file included from include/CXXGraph/Graph/Graph.h:34:
include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp: In member function ‘virtual const CXXGraph::DijkstraResult CXXGraph::Graph<T>::dijkstra(const CXXGraph::Node<T>&, const CXXGraph::Node<T>&) const’:
include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp:34:30: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   34 |   auto source_node_it = std::find_if(
      |                              ^~~~~~~
      |                              find
include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp:43:30: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   43 |   auto target_node_it = std::find_if(
      |                              ^~~~~~~
      |                              find
include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp:145:10: error: ‘reverse’ is not a member of ‘std’
  145 |     std::reverse(result.path.begin(), result.path.end());
      |          ^~~~~~~
In file included from include/CXXGraph/Graph/Graph.h:36:
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp: In member function ‘virtual double CXXGraph::Graph<T>::fordFulkersonMaxFlow(const CXXGraph::Node<T>&, const CXXGraph::Node<T>&) const’:
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:61:32: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   61 |   auto source_node_ptr = *std::find_if(
      |                                ^~~~~~~
      |                                find
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:64:32: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   64 |   auto target_node_ptr = *std::find_if(
      |                                ^~~~~~~
      |                                find
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp: In lambda function:
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:72:16: error: ‘source_node_ptr’ is not captured
   72 |     queue.push(source_node_ptr);
      |                ^~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:69:32: note: the lambda has no capture-default
   69 |                      &weightMap]() -> bool {
      |                                ^
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:61:8: note: ‘<typeprefixerror>source_node_ptr’ declared here
   61 |   auto source_node_ptr = *std::find_if(
      |        ^~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:73:13: error: ‘source_node_ptr’ is not captured
   73 |     visited[source_node_ptr] = true;
      |             ^~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:69:32: note: the lambda has no capture-default
   69 |                      &weightMap]() -> bool {
      |                                ^
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:61:8: note: ‘<typeprefixerror>source_node_ptr’ declared here
   61 |   auto source_node_ptr = *std::find_if(
      |        ^~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:74:12: error: ‘source_node_ptr’ is not captured
   74 |     parent[source_node_ptr] = nullptr;
      |            ^~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:69:32: note: the lambda has no capture-default
   69 |                      &weightMap]() -> bool {
      |                                ^
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:61:8: note: ‘<typeprefixerror>source_node_ptr’ declared here
   61 |   auto source_node_ptr = *std::find_if(
      |        ^~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:87:21: error: ‘target_node_ptr’ is not captured
   87 |     return (visited[target_node_ptr]);
      |                     ^~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:69:32: note: the lambda has no capture-default
   69 |                      &weightMap]() -> bool {
      |                                ^
include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp:64:8: note: ‘<typeprefixerror>target_node_ptr’ declared here
   64 |   auto target_node_ptr = *std::find_if(
      |        ^~~~~~~~~~~~~~~
In file included from include/CXXGraph/Graph/Graph.h:42:
include/CXXGraph/Graph/Algorithm/TopologicalSort_impl.hpp: In member function ‘virtual CXXGraph::TopoSortResult<T> CXXGraph::Graph<T>::topologicalSort() const’:
include/CXXGraph/Graph/Algorithm/TopologicalSort_impl.hpp:71:10: error: ‘reverse’ is not a member of ‘std’
   71 |     std::reverse(result.nodesInTopoOrder.begin(),
      |          ^~~~~~~
In file included from include/CXXGraph/Graph/Graph.h:47:
include/CXXGraph/Graph/IO/InputOperation_impl.hpp: In member function ‘int CXXGraph::Graph<T>::readFromDot(const std::string&, const std::string&)’:
include/CXXGraph/Graph/IO/InputOperation_impl.hpp:310:42: error: cannot convert ‘std::__cxx11::basic_string<char>::iterator’ to ‘const char*’
  310 |       node2.erase(std::remove(node2.begin(), node2.end(), ' '), node2.end());
      |                               ~~~~~~~~~~~^~
      |                                          |
      |                                          std::__cxx11::basic_string<char>::iterator
In file included from /usr/include/c++/14/cstdio:42,
                 from /usr/include/c++/14/ext/string_conversions.h:45,
                 from /usr/include/c++/14/bits/basic_string.h:4154,
                 from /usr/include/c++/14/string:54,
                 from /usr/include/c++/14/bits/locale_classes.h:40,
                 from /usr/include/c++/14/bits/ios_base.h:41,
                 from /usr/include/c++/14/ios:44,
                 from /usr/include/c++/14/ostream:40,
                 from /usr/include/c++/14/bits/unique_ptr.h:43,
                 from /usr/include/c++/14/memory:78,
                 from test_package.cpp:1:
/usr/include/stdio.h:158:32: note:   initializing argument 1 of ‘int remove(const char*)’
  158 | extern int remove (const char *__filename) __THROW;
      |                    ~~~~~~~~~~~~^~~~~~~~~~
include/CXXGraph/Graph/IO/InputOperation_impl.hpp:311:42: error: cannot convert ‘std::__cxx11::basic_string<char>::iterator’ to ‘const char*’
  311 |       node2.erase(std::remove(node2.begin(), node2.end(), '\t'), node2.end());
      |                               ~~~~~~~~~~~^~
      |                                          |
      |                                          std::__cxx11::basic_string<char>::iterator
/usr/include/stdio.h:158:32: note:   initializing argument 1 of ‘int remove(const char*)’
  158 | extern int remove (const char *__filename) __THROW;
      |                    ~~~~~~~~~~~~^~~~~~~~~~
include/CXXGraph/Graph/IO/InputOperation_impl.hpp:317:44: error: cannot convert ‘std::__cxx11::basic_string<char>::iterator’ to ‘const char*’
  317 |       weight.erase(std::remove(weight.begin(), weight.end(), ' '),
      |                                ~~~~~~~~~~~~^~
      |                                            |
      |                                            std::__cxx11::basic_string<char>::iterator
/usr/include/stdio.h:158:32: note:   initializing argument 1 of ‘int remove(const char*)’
  158 | extern int remove (const char *__filename) __THROW;
      |                    ~~~~~~~~~~~~^~~~~~~~~~
In file included from include/CXXGraph/Graph/Graph.h:48:
include/CXXGraph/Graph/IO/OutputOperation_impl.hpp: In member function ‘virtual int CXXGraph::Graph<T>::writeToMTXFile(const std::string&, const std::string&, char) const’:
include/CXXGraph/Graph/IO/OutputOperation_impl.hpp:161:26: error: ‘any_of’ is not a member of ‘std’
  161 |   bool symmetric = !std::any_of(edgeSet.begin(), edgeSet.end(), [](auto edge) {
      |                          ^~~~~~
In file included from include/CXXGraph/Graph/Graph.h:40:
include/CXXGraph/Graph/Algorithm/Prim_impl.hpp: In instantiation of ‘const CXXGraph::MstResult CXXGraph::Graph<T>::prim() const [with T = int; CXXGraph::MstResult = CXXGraph::MstResult_struct]’:
include/CXXGraph/Graph/Algorithm/Prim_impl.hpp:30:17:   required from here
include/CXXGraph/Graph/IO/OutputOperation_impl.hpp:161:26: error:    30 | const MstResult Graph<T>::prim() const {
include/CXXGraph/Graph/IO/OutputOperation_impl.hpp:161:26: error:       |                 ^~~~~~~~
include/CXXGraph/Graph/Algorithm/Prim_impl.hpp:75:18: error: no matching function for call to ‘find(std::vector<long unsigned int>::iterator, std::vector<long unsigned int>::iterator, long unsigned int&)’
   75 |     if (std::find(doneNode.begin(), doneNode.end(), nodeId) == doneNode.end()) {
      |         ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14/bits/locale_facets.h:48,
                 from /usr/include/c++/14/bits/basic_ios.h:37,
                 from /usr/include/c++/14/ios:46:
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
include/CXXGraph/Graph/Algorithm/Prim_impl.hpp:75:18: note:   ‘__gnu_cxx::__normal_iterator<long unsigned int*, std::vector<long unsigned int> >’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
   75 |     if (std::find(doneNode.begin(), doneNode.end(), nodeId) == doneNode.end()) {
      |         ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/Prim_impl.hpp:94:25: error: no matching function for call to ‘find(std::vector<long unsigned int>::iterator, std::vector<long unsigned int>::iterator, const CXXGraph::id_t&)’
   94 |               (std::find(doneNode.begin(), doneNode.end(),
      |                ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   95 |                          elem.first->getId()) == doneNode.end())) {
      |                          ~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
include/CXXGraph/Graph/Algorithm/Prim_impl.hpp:94:25: note:   ‘__gnu_cxx::__normal_iterator<long unsigned int*, std::vector<long unsigned int> >’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
   94 |               (std::find(doneNode.begin(), doneNode.end(),
      |                ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   95 |                          elem.first->getId()) == doneNode.end())) {
      |                          ~~~~~~~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp: In instantiation of ‘CXXGraph::BestFirstSearchResult<T> CXXGraph::Graph<T>::best_first_search(const CXXGraph::Node<T>&, const CXXGraph::Node<T>&) const [with T = int; CXXGraph::BestFirstSearchResult<T> = CXXGraph::BestFirstSearchResult_struct<int>]’:
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:34:26:   required from here
include/CXXGraph/Graph/Algorithm/Prim_impl.hpp:94:25: note:    34 | BestFirstSearchResult<T> Graph<T>::best_first_search(
include/CXXGraph/Graph/Algorithm/Prim_impl.hpp:94:25: note:       |                          ^~~~~~~~
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:77:26: error: no matching function for call to ‘find(std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > >::iterator, std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > >::iterator, std::__shared_ptr_access<const CXXGraph::Node<int>, __gnu_cxx::_S_atomic, false, false>::element_type&)’
   77 |             if (std::find(visited.begin(), visited.end(), *(elem.first)) ==
      |                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:77:26: note:   ‘__gnu_cxx::__normal_iterator<CXXGraph::Node<int>*, std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > > >’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
   77 |             if (std::find(visited.begin(), visited.end(), *(elem.first)) ==
      |                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:86:26: error: no matching function for call to ‘find(std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > >::iterator, std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > >::iterator, std::__shared_ptr_access<const CXXGraph::Node<int>, __gnu_cxx::_S_atomic, false, false>::element_type&)’
   86 |             if (std::find(visited.begin(), visited.end(), *(elem.first)) ==
      |                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:86:26: note:   ‘__gnu_cxx::__normal_iterator<CXXGraph::Node<int>*, std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > > >’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
   86 |             if (std::find(visited.begin(), visited.end(), *(elem.first)) ==
      |                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp: In instantiation of ‘const std::vector<CXXGraph::Node<T> > CXXGraph::Graph<T>::breadth_first_search(const CXXGraph::Node<T>&) const [with T = int]’:
include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp:30:28:   required from here
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:86:26: note:    30 | const std::vector<Node<T>> Graph<T>::breadth_first_search(
include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp:86:26: note:       |                            ^~~~~~~~
include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp:55:22: error: no matching function for call to ‘find(std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > >::iterator, std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > >::iterator, std::__shared_ptr_access<const CXXGraph::Node<int>, __gnu_cxx::_S_atomic, false, false>::element_type&)’
   55 |         if (std::find(visited.begin(), visited.end(), *(elem.first)) ==
      |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp:55:22: note:   ‘__gnu_cxx::__normal_iterator<CXXGraph::Node<int>*, std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > > >’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
   55 |         if (std::find(visited.begin(), visited.end(), *(elem.first)) ==
      |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp: In instantiation of ‘const std::vector<CXXGraph::Node<T> > CXXGraph::Graph<T>::depth_first_search(const CXXGraph::Node<T>&) const [with T = int]’:
include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp:30:28:   required from here
include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp:55:22: note:    30 | const std::vector<Node<T>> Graph<T>::depth_first_search(
include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp:55:22: note:       |                            ^~~~~~~~
include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp:51:22: error: no matching function for call to ‘find(std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > >::iterator, std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > >::iterator, std::__shared_ptr_access<const CXXGraph::Node<int>, __gnu_cxx::_S_atomic, false, false>::element_type&)’
   51 |         if (std::find(visited.begin(), visited.end(), *(x.first)) ==
      |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp:51:22: note:   ‘__gnu_cxx::__normal_iterator<CXXGraph::Node<int>*, std::vector<CXXGraph::Node<int>, std::allocator<CXXGraph::Node<int> > > >’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
   51 |         if (std::find(visited.begin(), visited.end(), *(x.first)) ==
      |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/CXXGraph/Graph/Algorithm/Dial_impl.hpp: In instantiation of ‘const CXXGraph::DialResult CXXGraph::Graph<T>::dial(const CXXGraph::Node<T>&, int) const [with T = int; CXXGraph::DialResult = CXXGraph::DialResult_struct]’:
include/CXXGraph/Graph/Algorithm/Dial_impl.hpp:30:18:   required from here
include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp:51:22: note:    30 | const DialResult Graph<T>::dial(const Node<T> &source, int maxWeight) const {
include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp:51:22: note:       |                  ^~~~~~~~
include/CXXGraph/Graph/Algorithm/Dial_impl.hpp:134:36: error: no matching function for call to ‘find(std::deque<std::shared_ptr<const CXXGraph::Node<int> >, std::allocator<std::shared_ptr<const CXXGraph::Node<int> > > >::iterator, std::deque<std::shared_ptr<const CXXGraph::Node<int> >, std::allocator<std::shared_ptr<const CXXGraph::Node<int> > > >::iterator, std::shared_ptr<const CXXGraph::Node<int> >&)’
  134 |           auto findIter = std::find(B[dv].begin(), B[dv].end(), dist[v].second);
      |                           ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note: candidate: ‘template<class _CharT2> typename __gnu_cxx::__enable_if<std::__is_char<_CharT2>::__value, std::istreambuf_iterator<_CharT, std::char_traits<_CharT> > >::__type std::find(istreambuf_iterator<_CharT, char_traits<_CharT> >, istreambuf_iterator<_CharT, char_traits<_CharT> >, const _CharT2&)’
  435 |     find(istreambuf_iterator<_CharT> __first,
      |     ^~~~
/usr/include/c++/14/bits/streambuf_iterator.h:435:5: note:   template argument deduction/substitution failed:
include/CXXGraph/Graph/Algorithm/Dial_impl.hpp:134:36: note:   ‘std::_Deque_iterator<std::shared_ptr<const CXXGraph::Node<int> >, std::shared_ptr<const CXXGraph::Node<int> >&, std::shared_ptr<const CXXGraph::Node<int> >*>’ is not derived from ‘std::istreambuf_iterator<_CharT, std::char_traits<_CharT> >’
  134 |           auto findIter = std::find(B[dv].begin(), B[dv].end(), dist[v].second);
      |                           ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
</details>
