### PR TITLE
Bug Fix for #418 - Graph<T>::removeNode has potential to throw due to optional being accessed early

### DIFF
--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -233,7 +233,7 @@ template <typename T>
 void Graph<T>::removeNode(const std::string &nodeUserId) {
   auto nodeOpt = getNode(nodeUserId);
   if (nodeOpt.has_value()) {
-    auto isolatedNodeIt  = isolatedNodesSet.find(nodeOpt.value());
+    auto isolatedNodeIt = isolatedNodesSet.find(nodeOpt.value());
     if (isolatedNodeIt != isolatedNodesSet.end()) {
       // The node is isolated
       isolatedNodesSet.erase(isolatedNodeIt);
@@ -242,17 +242,16 @@ void Graph<T>::removeNode(const std::string &nodeUserId) {
       // Remove the edges containing the node
       auto edgeIt = edgeSet.begin();
       auto nextIt = edgeIt;
-      while(edgeIt != edgeSet.end()) {
+      while (edgeIt != edgeSet.end()) {
         nextIt = std::next(edgeIt);
         if ((*edgeIt)->getNodePair().first->getUserId() == nodeUserId ||
             (*edgeIt)->getNodePair().second->getUserId() == nodeUserId) {
-          
           this->removeEdge((*edgeIt)->getId());
         }
         edgeIt = nextIt;
       }
     }
-  }  
+  }
 }
 
 template <typename T>

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -232,8 +232,11 @@ void Graph<T>::removeEdge(const CXXGraph::id_t edgeId) {
 template <typename T>
 void Graph<T>::removeNode(const std::string &nodeUserId) {
   auto nodeOpt = getNode(nodeUserId);
-  auto isolatedNodeIt = isolatedNodesSet.find(nodeOpt.value());
-
+  auto isolatedNodeIt = isolatedNodesSet.end();
+  if (nodeOpt) {
+    isolatedNodeIt  = isolatedNodeIt.find(nodeOpt.value());
+  }
+  
   if (nodeOpt.has_value() && isolatedNodeIt != isolatedNodesSet.end()) {
     // The node is isolated
     isolatedNodesSet.erase(isolatedNodeIt);

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -234,7 +234,7 @@ void Graph<T>::removeNode(const std::string &nodeUserId) {
   auto nodeOpt = getNode(nodeUserId);
   auto isolatedNodeIt = isolatedNodesSet.end();
   if (nodeOpt) {
-    isolatedNodeIt  = isolatedNodeIt.find(nodeOpt.value());
+    isolatedNodeIt  = isolatedNodesSet.find(nodeOpt.value());
   }
   
   if (nodeOpt.has_value() && isolatedNodeIt != isolatedNodesSet.end()) {

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -232,7 +232,7 @@ void Graph<T>::removeEdge(const CXXGraph::id_t edgeId) {
 template <typename T>
 void Graph<T>::removeNode(const std::string &nodeUserId) {
   auto nodeOpt = getNode(nodeUserId);
-  if (nodeOpt) {
+  if (nodeOpt.has_value()) {
     auto isolatedNodeIt  = isolatedNodesSet.find(nodeOpt.value());
     if (isolatedNodeIt != isolatedNodesSet.end()) {
       // The node is isolated
@@ -240,12 +240,16 @@ void Graph<T>::removeNode(const std::string &nodeUserId) {
     } else {
       // The node is not isolated
       // Remove the edges containing the node
-      auto edgeset = edgeSet;
-      for (auto edgeIt : edgeset) {
-        if (edgeIt->getNodePair().first->getUserId() == nodeUserId ||
-            edgeIt->getNodePair().second->getUserId() == nodeUserId) {
-          this->removeEdge(edgeIt->getId());
+      auto edgeIt = edgeSet.begin();
+      auto nextIt = edgeIt;
+      while(edgeIt != edgeSet.end()) {
+        nextIt = std::next(edgeIt);
+        if ((*edgeIt)->getNodePair().first->getUserId() == nodeUserId ||
+            (*edgeIt)->getNodePair().second->getUserId() == nodeUserId) {
+          
+          this->removeEdge((*edgeIt)->getId());
         }
+        edgeIt = nextIt;
       }
     }
   }  

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -232,25 +232,23 @@ void Graph<T>::removeEdge(const CXXGraph::id_t edgeId) {
 template <typename T>
 void Graph<T>::removeNode(const std::string &nodeUserId) {
   auto nodeOpt = getNode(nodeUserId);
-  auto isolatedNodeIt = isolatedNodesSet.end();
   if (nodeOpt) {
-    isolatedNodeIt  = isolatedNodesSet.find(nodeOpt.value());
-  }
-  
-  if (nodeOpt.has_value() && isolatedNodeIt != isolatedNodesSet.end()) {
-    // The node is isolated
-    isolatedNodesSet.erase(isolatedNodeIt);
-  } else if (nodeOpt.has_value()) {
-    // The node is not isolated
-    // Remove the edges containing the node
-    auto edgeset = edgeSet;
-    for (auto edgeIt : edgeset) {
-      if (edgeIt->getNodePair().first->getUserId() == nodeUserId ||
-          edgeIt->getNodePair().second->getUserId() == nodeUserId) {
-        this->removeEdge(edgeIt->getId());
+    auto isolatedNodeIt  = isolatedNodesSet.find(nodeOpt.value());
+    if (isolatedNodeIt != isolatedNodesSet.end()) {
+      // The node is isolated
+      isolatedNodesSet.erase(isolatedNodeIt);
+    } else {
+      // The node is not isolated
+      // Remove the edges containing the node
+      auto edgeset = edgeSet;
+      for (auto edgeIt : edgeset) {
+        if (edgeIt->getNodePair().first->getUserId() == nodeUserId ||
+            edgeIt->getNodePair().second->getUserId() == nodeUserId) {
+          this->removeEdge(edgeIt->getId());
+        }
       }
     }
-  }
+  }  
 }
 
 template <typename T>

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -1340,6 +1340,45 @@ TEST(TestRemoveNode, Test_connectedNode) {
   ASSERT_EQ(graph.getEdgeSet().size(), 1);
 }
 
+TEST(TestRemoveNode, Test_removeInvalidNode) {
+  /** Test to call the remove_node function on a node that was never added. In this case getNode will return an optional that is nullptr*/
+  // Create a graph with 3 nodes and 3 edges.
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 2);
+  CXXGraph::Node<int> node3("3", 3);
+  CXXGraph::DirectedEdge<int> edge1(1, node1, node2);
+  CXXGraph::DirectedEdge<int> edge2(2, node2, node1);
+  CXXGraph::DirectedEdge<int> edge3(3, node1, node3);
+  CXXGraph::T_EdgeSet<int> edgeSet;
+  // Add the 3 edges into the graph.
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge1));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge2));
+  edgeSet.insert(make_shared<CXXGraph::Edge<int>>(edge3));
+  // Initialise the graph
+  CXXGraph::Graph<int> graph(edgeSet);
+
+  // Check the initial number of edges and nodes. Everything should be okay so far
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+
+  // Remove a node that was never in the graph
+  graph.removeNode("4");
+
+  // Number of nodes and edges in the graph should remain the same
+  ASSERT_EQ(graph.getNodeSet().size(), 3);
+  ASSERT_EQ(graph.getEdgeSet().size(), 3);
+
+  // Remove an existing node, the edge associated with that node should also be removed. Node "3" had just outgoing edge, so there should now be 2 nodes and 2 edges.
+  graph.removeNode("3");
+  ASSERT_EQ(graph.getNodeSet().size(), 2);
+  ASSERT_EQ(graph.getEdgeSet().size(), 2);
+
+  // Remove the node that had already been removed. Should not change anything about the graph now, similar to when "4" was removed above
+  graph.removeNode("3");
+  ASSERT_EQ(graph.getNodeSet().size(), 2);
+  ASSERT_EQ(graph.getEdgeSet().size(), 2);
+}
+
 TEST(TestGetNode, Test_1) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -1341,7 +1341,8 @@ TEST(TestRemoveNode, Test_connectedNode) {
 }
 
 TEST(TestRemoveNode, Test_removeInvalidNode) {
-  /** Test to call the remove_node function on a node that was never added. In this case getNode will return an optional that is nullptr*/
+  /** Test to call the remove_node function on a node that was never added. In
+   * this case getNode will return an optional that is nullptr*/
   // Create a graph with 3 nodes and 3 edges.
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);
@@ -1357,7 +1358,8 @@ TEST(TestRemoveNode, Test_removeInvalidNode) {
   // Initialise the graph
   CXXGraph::Graph<int> graph(edgeSet);
 
-  // Check the initial number of edges and nodes. Everything should be okay so far
+  // Check the initial number of edges and nodes. Everything should be okay so
+  // far
   ASSERT_EQ(graph.getNodeSet().size(), 3);
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
 
@@ -1368,12 +1370,15 @@ TEST(TestRemoveNode, Test_removeInvalidNode) {
   ASSERT_EQ(graph.getNodeSet().size(), 3);
   ASSERT_EQ(graph.getEdgeSet().size(), 3);
 
-  // Remove an existing node, the edge associated with that node should also be removed. Node "3" had just outgoing edge, so there should now be 2 nodes and 2 edges.
+  // Remove an existing node, the edge associated with that node should also be
+  // removed. Node "3" had just outgoing edge, so there should now be 2 nodes
+  // and 2 edges.
   graph.removeNode("3");
   ASSERT_EQ(graph.getNodeSet().size(), 2);
   ASSERT_EQ(graph.getEdgeSet().size(), 2);
 
-  // Remove the node that had already been removed. Should not change anything about the graph now, similar to when "4" was removed above
+  // Remove the node that had already been removed. Should not change anything
+  // about the graph now, similar to when "4" was removed above
   graph.removeNode("3");
   ASSERT_EQ(graph.getNodeSet().size(), 2);
   ASSERT_EQ(graph.getEdgeSet().size(), 2);


### PR DESCRIPTION
Pull Request for Bug #418. 
- Issue: Graph<T>::removeNode does not check whether the node to be removed is actually present in the graph. 
- Changes: Graph<T>::removeNode now checks whether the std::optional node obtained from Graph<T>::getNode() is indeed present in the Graph or not. If not present, the function does nothing. There is also a test called Test_removeInvalidNode within GraphTest.cpp. 
