### PR TITLE
Add nullptr guard-check in comparision of shared ptr node and edge

### DIFF
--- a/include/CXXGraph/Utility/PointerHash.hpp
+++ b/include/CXXGraph/Utility/PointerHash.hpp
@@ -73,7 +73,7 @@ template <typename T>
 bool operator==(shared<const Edge<T>> p1, shared<const Edge<T>> p2) {
   if (p1 == nullptr && p2 == nullptr) return true;
   if (p1 == nullptr || p2 == nullptr) return false;
-  
+
   return p1->getNodePair().first->getUserId() ==
              p2->getNodePair().first->getUserId() &&
          p1->getNodePair().second->getUserId() ==

--- a/include/CXXGraph/Utility/PointerHash.hpp
+++ b/include/CXXGraph/Utility/PointerHash.hpp
@@ -57,16 +57,23 @@ struct edgeHash {
 
 template <typename T>
 bool operator==(shared<const Node<T>> p1, shared<const Node<T>> p2) {
+  if (p1 == nullptr && p2 == nullptr) return true;
+  if (p1 == nullptr || p2 == nullptr) return false;
   return p1->getUserId() == p2->getUserId();
 }
 
 template <typename T>
 bool operator==(shared<Node<T>> p1, shared<Node<T>> p2) {
+  if (p1 == nullptr && p2 == nullptr) return true;
+  if (p1 == nullptr || p2 == nullptr) return false;
   return p1->getUserId() == p2->getUserId();
 }
 
 template <typename T>
 bool operator==(shared<const Edge<T>> p1, shared<const Edge<T>> p2) {
+  if (p1 == nullptr && p2 == nullptr) return true;
+  if (p1 == nullptr || p2 == nullptr) return false;
+  
   return p1->getNodePair().first->getUserId() ==
              p2->getNodePair().first->getUserId() &&
          p1->getNodePair().second->getUserId() ==


### PR DESCRIPTION
Fixes Clang's critical bug on the library where we're doing custom shared_ptr comparison with potentially null ptrs.

This will fix #433 but i think what we should also be doing is enforce nullptr safety on these custom operators on shared ptrs

This allows Clang on MacOS to pass all tests.

- A description of the changes proposed in the pull request.
I added 
```C++
...
  if (p1 == nullptr && p2 == nullptr) return true;
  if (p1 == nullptr || p2 == nullptr) return false;
...
```

to == operator in PointerHash()

@ZigRazor would love a review
