### PR TITLE
Remove vector in definition of `DegreeMatrix`

### DIFF
--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -545,9 +545,8 @@ shared<DegreeMatrix<T>> Graph<T>::getDegreeMatrix() const {
     const std::vector<std::pair<shared<const Node<T>>, shared<const Edge<T>>>>
         &neighbors = nodePair.second;
 
-    int degree = (int)neighbors.size();
-
-    (*degreeMatrix)[node] = {degree};
+    const int degree = neighbors.size();
+    (*degreeMatrix)[node] = degree;
   }
 
   return degreeMatrix;

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -545,8 +545,7 @@ shared<DegreeMatrix<T>> Graph<T>::getDegreeMatrix() const {
     const std::vector<std::pair<shared<const Node<T>>, shared<const Edge<T>>>>
         &neighbors = nodePair.second;
 
-    const int degree = neighbors.size();
-    (*degreeMatrix)[node] = degree;
+    (*degreeMatrix)[node] = neighbors.size();
   }
 
   return degreeMatrix;

--- a/include/CXXGraph/Utility/Typedef.hpp
+++ b/include/CXXGraph/Utility/Typedef.hpp
@@ -249,7 +249,7 @@ using AdjacencyMatrix = std::unordered_map<
 
 template <typename T>
 using DegreeMatrix =
-    std::unordered_map<shared<const Node<T>>, std::vector<int>, nodeHash<T>>;
+    std::unordered_map<shared<const Node<T>>, unsigned int, nodeHash<T>>;
 
 template <typename T>
 using LaplacianMatrix = std::unordered_map<


### PR DESCRIPTION
While working on #454 I noticed that we define the `DegreeMatrix` by placing the degree value for each node inside a vector. This seems a bit excessive, since it can only be a single unsigned integer, and it makes it a bit more verbose to use as well. I redefined it and updated the getter. 
@ZigRazor @nolankramer let me know if you agree :)