### PR TITLE
Fix warnings in compilation of tests

### DIFF
--- a/include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp
@@ -67,7 +67,7 @@ const BellmanFordResult Graph<T>::bellmanford(const Node<T> &source,
   // iterations remain the same.
   auto earlyStopping = false;
   // outer loop for vertex relaxation
-  for (int i = 0; i < n - 1; ++i) {
+  for (size_t i = 0; i < n - 1; ++i) {
     auto edgeSet = Graph<T>::getEdgeSet();
     // inner loop for distance updates of
     // each relaxation

--- a/include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp
@@ -209,7 +209,7 @@ const std::vector<Node<T>> Graph<T>::concurrency_breadth_first_search(
 
       // last worker need to do preparation for the next iteration
       int cur_level = level;
-      if (num_threads == 1 + waiting_workers.fetch_add(1)) {
+      if (num_threads == 1u + waiting_workers.fetch_add(1u)) {
         swap(level_tracker, next_level_tracker);
         next_level_tracker.clear();
 
@@ -240,7 +240,7 @@ const std::vector<Node<T>> Graph<T>::concurrency_breadth_first_search(
   };
 
   std::vector<std::thread> workers;
-  for (int i = 0; i < num_threads - 1; ++i) {
+  for (size_t i = 0; i < num_threads - 1; ++i) {
     workers.emplace_back(std::thread(bfs_worker));
   }
   bfs_worker();

--- a/include/CXXGraph/Graph/Algorithm/Connectivity_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Connectivity_impl.hpp
@@ -43,7 +43,7 @@ bool Graph<T>::isConnectedGraph() const {
           visited[source->getId()] = true;
 
           // travel the neighbors
-          for (int i = 0; i < (*cachedAdjMatrix)[source].size(); i++) {
+          for (size_t i = 0; i < (*cachedAdjMatrix)[source].size(); i++) {
             shared<const Node<T>> neighbor =
                 (*cachedAdjMatrix)[source].at(i).first;
             if (visited[neighbor->getId()] == false) {
@@ -83,7 +83,7 @@ bool Graph<T>::isStronglyConnectedGraph() const {
             visited[source->getId()] = true;
 
             // travel the neighbors
-            for (int i = 0; i < (*cachedAdjMatrix)[source].size(); i++) {
+            for (size_t i = 0; i < (*cachedAdjMatrix)[source].size(); i++) {
               shared<const Node<T>> neighbor =
                   (*cachedAdjMatrix)[source].at(i).first;
               if (visited[neighbor->getId()] == false) {

--- a/include/CXXGraph/Graph/Algorithm/Dial_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dial_impl.hpp
@@ -65,7 +65,7 @@ const DialResult Graph<T>::dial(const Node<T> &source, int maxWeight) const {
   B[0].push_back(*source_node_it);
   dist[*source_node_it].first = 0;
 
-  int idx = 0;
+  std::size_t idx = 0;
   while (true) {
     // Go sequentially through buckets till one non-empty
     // bucket is found

--- a/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
@@ -51,7 +51,8 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T>& source,
     return result;
   }
   // n denotes the number of vertices in graph
-  auto n = cachedAdjMatrix->size();
+  // unused
+  //auto n = cachedAdjMatrix->size();
 
   // setting all the distances initially to INF_DOUBLE
   std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
@@ -175,7 +176,8 @@ const DijkstraResult Graph<T>::dijkstra_deterministic(
     return result;
   }
   // n denotes the number of vertices in graph
-  auto n = cachedAdjMatrix->size();
+  // unused
+  //auto n = cachedAdjMatrix->size();
 
   // setting all the distances initially to INF_DOUBLE
   std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;
@@ -322,7 +324,8 @@ const DijkstraResult Graph<T>::dijkstra_deterministic2(
     return result;
   }
   // n denotes the number of vertices in graph
-  auto n = cachedAdjMatrix->size();
+  // unused
+  // auto n = cachedAdjMatrix->size();
 
   // setting all the distances initially to INF_DOUBLE
   std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;

--- a/include/CXXGraph/Graph/Algorithm/Kosaraju_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Kosaraju_impl.hpp
@@ -51,7 +51,7 @@ SCCResult<T> Graph<T>::kosaraju() const {
           visited[source->getId()] = true;
 
           // travel the neighbors
-          for (int i = 0; i < (*cachedAdjMatrix)[source].size(); i++) {
+          for (size_t i = 0; i < (*cachedAdjMatrix)[source].size(); i++) {
             shared<const Node<T>> neighbor =
                 (*cachedAdjMatrix)[source].at(i).first;
             if (visited[neighbor->getId()] == false) {
@@ -99,7 +99,7 @@ SCCResult<T> Graph<T>::kosaraju() const {
           result.sccMap[source->getId()] = sccLabel;
 
           // travel the neighbors
-          for (int i = 0; i < rev[source].size(); i++) {
+          for (size_t i = 0; i < rev[source].size(); i++) {
             shared<const Node<T>> neighbor = rev[source].at(i).first;
             if (visited[neighbor->getId()] == false) {
               // make recursive call from neighbor

--- a/include/CXXGraph/Graph/Algorithm/Prim_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Prim_impl.hpp
@@ -41,7 +41,8 @@ const MstResult Graph<T>::prim() const {
     return result;
   }
   auto nodeSet = Graph<T>::getNodeSet();
-  auto n = nodeSet.size();
+  // unused
+  /* auto n = nodeSet.size(); */
 
   // setting all the distances initially to INF_DOUBLE
   std::unordered_map<shared<const Node<T>>, double, nodeHash<T>> dist;

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -463,7 +463,8 @@ std::shared_ptr<std::vector<Node<T>>> Graph<T>::eulerianPath() const {
   std::shared_ptr<std::vector<Node<T>>> eulerPath =
       std::make_shared<std::vector<Node<T>>>();
 
-  bool undirected = this->isUndirectedGraph();
+  // unused
+  // bool undirected = this->isUndirectedGraph();
 
   std::vector<shared<const Node<T>>> currentPath;
   // The starting node is the only node which has more outgoing than ingoing

--- a/include/CXXGraph/Graph/IO/InputOperation_impl.hpp
+++ b/include/CXXGraph/Graph/IO/InputOperation_impl.hpp
@@ -181,8 +181,8 @@ int Graph<T>::readFromMTXFile(const std::string &workingDir,
   }
 
   // Define the number of columns and rows in the matrix
-  int n_cols, n_rows;
-  int n_edges;
+  std::size_t n_cols, n_rows;
+  std::size_t n_edges;
   bool undirected = false;
 
   // From the first line of the file read the number of rows, columns and edges
@@ -201,11 +201,11 @@ int Graph<T>::readFromMTXFile(const std::string &workingDir,
   std::stringstream header_stream(row_content);
   std::string value;
   getline(header_stream, value, ' ');
-  n_rows = std::stoi(value);
+  n_rows = std::stoul(value);
   getline(header_stream, value, ' ');
-  n_cols = std::stoi(value);
+  n_cols = std::stoul(value);
   getline(header_stream, value, ' ');
-  n_edges = std::stoi(value);
+  n_edges = std::stoul(value);
 
   // Since the matrix represents the adjacency matrix, it must be square
   if (n_rows != n_cols) {

--- a/include/CXXGraph/Graph/IO/OutputOperation_impl.hpp
+++ b/include/CXXGraph/Graph/IO/OutputOperation_impl.hpp
@@ -124,9 +124,9 @@ int Graph<T>::writeToFile(InputOutputFormat format,
       return _result;
     };
     if (format == InputOutputFormat::STANDARD_CSV) {
-      auto result = _compress(".csv");
+      result = _compress(".csv");
     } else if (format == InputOutputFormat::STANDARD_TSV) {
-      auto result = _compress(".tsv");
+      result = _compress(".tsv");
     } else {
       // OUTPUT FORMAT NOT RECOGNIZED
       result = -1;

--- a/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
@@ -182,7 +182,7 @@ int CoordinatedPartitionState<T>::getMachineWithMinWeight() const {
 
   double MIN_LOAD = std::numeric_limits<double>::max();
   int machine_id = 0;
-  for (int i = 0; i < machines_weight_edges.size(); ++i) {
+  for (size_t i = 0; i < machines_weight_edges.size(); ++i) {
     double loadi = machines_weight_edges[i];
     if (loadi < MIN_LOAD) {
       MIN_LOAD = loadi;

--- a/test/BFSTest.cpp
+++ b/test/BFSTest.cpp
@@ -315,7 +315,7 @@ TEST(BFSTest, test_13) {
       edgeSet.insert(newEdge);
     }
   }
-  for (int i = 1; i < nodes.size(); i += 2) {
+  for (size_t i = 1; i < nodes.size(); i += 2) {
     shared<CXXGraph::UndirectedEdge<int>> newEdge =
         make_shared<CXXGraph::UndirectedEdge<int>>(
             edges_size + i + 1, *(nodes.at(0)), *(nodes.at(i)));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,10 @@ endif(CODE_COVERAGE)
 option(TEST "Enable Test" OFF)
 if(TEST)
     include(${CPM_DOWNLOAD_LOCATION})
+	add_compile_options(
+	  -Wall
+	  -Wextra
+	)
 
     CPMAddPackage(
         NAME googletest

--- a/test/KahnTest.cpp
+++ b/test/KahnTest.cpp
@@ -92,7 +92,7 @@ TEST(KahnTest, correct_example_small) {
   ASSERT_EQ(res.nodesInTopoOrder.size(), graph.getNodeSet().size());
 
   std::unordered_map<CXXGraph::id_t, int> topOrderNodeIds;
-  for (int i = 0; i < res.nodesInTopoOrder.size(); ++i) {
+  for (size_t i = 0; i < res.nodesInTopoOrder.size(); ++i) {
     topOrderNodeIds[res.nodesInTopoOrder[i].getId()] = i;
   }
 
@@ -161,7 +161,7 @@ TEST(KahnTest, correct_example_big) {
   ASSERT_EQ(res.nodesInTopoOrder.size(), graph.getNodeSet().size());
 
   std::unordered_map<CXXGraph::id_t, int> topOrderNodeIds;
-  for (int i = 0; i < res.nodesInTopoOrder.size(); ++i) {
+  for (size_t i = 0; i < res.nodesInTopoOrder.size(); ++i) {
     topOrderNodeIds[res.nodesInTopoOrder[i].getId()] = i;
   }
 

--- a/test/KosarajuTest.cpp
+++ b/test/KosarajuTest.cpp
@@ -18,9 +18,9 @@ void compareComponents(CXXGraph::SCCResult<int> result,
                        CXXGraph::Components<int>& comp2) {
   ASSERT_EQ(result.noOfComponents, comp2.size());
 
-  for (int i = 0; i < comp2.size(); i++) {
+  for (size_t i = 0; i < comp2.size(); i++) {
     int curComp = result.sccMap[comp2[i][0].getId()];
-    for (int j = 1; j < comp2[i].size(); j++) {
+    for (size_t j = 1; j < comp2[i].size(); j++) {
       ASSERT_EQ(result.sccMap[comp2[i][j].getId()], curComp);
     }
   }

--- a/test/TarjanTest.cpp
+++ b/test/TarjanTest.cpp
@@ -95,9 +95,9 @@ TEST(TarjanTest, test_2) {
   }
   std::vector<std::vector<CXXGraph::Node<int>>> expectRes{
       {node9}, {node4, node5}, {node1, node2, node3}, {node6, node7, node8}};
-  for (int i = 0; i < 4; ++i) {
+  for (short i = 0; i < 4; ++i) {
     ASSERT_EQ(res.stronglyConnectedComps[i].size(), expectRes[i].size());
-    for (int j = 0; j < expectRes[i].size(); ++j) {
+    for (size_t j = 0; j < expectRes[i].size(); ++j) {
       ASSERT_EQ(res.stronglyConnectedComps[i][j], expectRes[i][j]);
     }
   }
@@ -113,7 +113,7 @@ TEST(TarjanTest, test_3) {
   // https://en.wikipedia.org/wiki/Biconnected_component#/media/File:Block-cut_tree2.svg
   std::vector<CXXGraph::Node<int>> nodes;
   nodes.emplace_back("0", 0);
-  for (int i = 1; i <= 18; ++i) {
+  for (short i = 1; i <= 18; ++i) {
     nodes.emplace_back(std::to_string(i), i);
   };
   std::vector<std::pair<int, int>> pairs{
@@ -139,7 +139,7 @@ TEST(TarjanTest, test_3) {
             [&](const auto &node1, const auto &node2) {
               return node1.getData() < node2.getData();
             });
-  for (int i = 0; i < expectRes.size(); ++i) {
+  for (size_t i = 0; i < expectRes.size(); ++i) {
     ASSERT_EQ(res.cutVertices[i], nodes[expectRes[i]]);
   }
   // check whether other types of functions are not be executed
@@ -154,7 +154,7 @@ TEST(TarjanTest, test_4) {
   // https://en.wikipedia.org/wiki/Biconnected_component#/media/File:Block-cut_tree2.svg
   std::vector<CXXGraph::Node<int>> nodes;
   nodes.emplace_back("0", 0);
-  for (int i = 1; i <= 18; ++i) {
+  for (short i = 1; i <= 18; ++i) {
     nodes.emplace_back(std::to_string(i), i);
   };
   std::vector<std::pair<int, int>> pairs{
@@ -200,9 +200,9 @@ TEST(TarjanTest, test_4) {
               }
               return scc1[0].getData() < scc2[0].getData();
             });
-  for (int i = 0; i < res.verticeBiconnectedComps.size(); ++i) {
+  for (size_t i = 0; i < res.verticeBiconnectedComps.size(); ++i) {
     ASSERT_EQ(res.verticeBiconnectedComps[i].size(), expectRes[i].size());
-    for (int j = 0; j < expectRes[i].size(); ++j) {
+    for (size_t j = 0; j < expectRes[i].size(); ++j) {
       ASSERT_EQ(res.verticeBiconnectedComps[i][j], expectRes[i][j]);
     }
   }
@@ -218,7 +218,7 @@ TEST(TarjanTest, test_5) {
   // codeforce https://codeforces.com/blog/entry/99259
   std::vector<CXXGraph::Node<int>> nodes;
   nodes.emplace_back("0", 0);
-  for (int i = 1; i <= 12; ++i) {
+  for (short i = 1; i <= 12; ++i) {
     nodes.emplace_back(std::to_string(i), i);
   };
   std::vector<std::pair<int, int>> pairs{
@@ -243,7 +243,7 @@ TEST(TarjanTest, test_5) {
             [&](const auto &edge1, const auto &edge2) {
               return edge1.getId() < edge2.getId();
             });
-  for (int i = 0; i < expectRes.size(); ++i) {
+  for (size_t i = 0; i < expectRes.size(); ++i) {
     ASSERT_EQ(res.bridges[i], edges[expectRes[i]]);
   }
   // check whether other types of functions are not be executed
@@ -258,7 +258,7 @@ TEST(TarjanTest, test_6) {
   // codeforce https://codeforces.com/blog/entry/99259
   std::vector<CXXGraph::Node<int>> nodes;
   nodes.emplace_back("0", 0);
-  for (int i = 1; i <= 12; ++i) {
+  for (short i = 1; i <= 12; ++i) {
     nodes.emplace_back(std::to_string(i), i);
   };
   std::vector<std::pair<int, int>> pairs{
@@ -298,9 +298,9 @@ TEST(TarjanTest, test_6) {
               }
               return scc1[0].getData() < scc2[0].getData();
             });
-  for (int i = 0; i < res.edgeBiconnectedComps.size(); ++i) {
+  for (size_t i = 0; i < res.edgeBiconnectedComps.size(); ++i) {
     ASSERT_EQ(res.edgeBiconnectedComps[i].size(), expectRes[i].size());
-    for (int j = 0; j < expectRes[i].size(); ++j) {
+    for (size_t j = 0; j < expectRes[i].size(); ++j) {
       ASSERT_EQ(res.edgeBiconnectedComps[i][j], expectRes[i][j]);
     }
   }
@@ -316,7 +316,7 @@ TEST(TarjanTest, test_7) {
   // https://en.wikipedia.org/wiki/Biconnected_component#/media/File:Block-cut_tree2.svg
   std::vector<CXXGraph::Node<int>> nodes;
   nodes.emplace_back("0", 0);
-  for (int i = 1; i <= 18; ++i) {
+  for (short i = 1; i <= 18; ++i) {
     nodes.emplace_back(std::to_string(i), i);
   };
   std::vector<std::pair<int, int>> pairs{
@@ -348,29 +348,29 @@ TEST(TarjanTest, test_7) {
   ASSERT_EQ(res.success, true);
 
   ASSERT_EQ(res.cutVertices.size(), cutvRes.cutVertices.size());
-  for (int i = 0; i < cutvRes.cutVertices.size(); ++i) {
+  for (size_t i = 0; i < cutvRes.cutVertices.size(); ++i) {
     ASSERT_EQ(cutvRes.cutVertices[i], res.cutVertices[i]);
   }
   ASSERT_EQ(res.bridges.size(), bridgeRes.bridges.size());
-  for (int i = 0; i < bridgeRes.cutVertices.size(); ++i) {
+  for (size_t i = 0; i < bridgeRes.cutVertices.size(); ++i) {
     ASSERT_EQ(bridgeRes.bridges[i], res.bridges[i]);
   }
   ASSERT_EQ(res.edgeBiconnectedComps.size(),
             ebccRes.edgeBiconnectedComps.size());
-  for (int i = 0; i < res.edgeBiconnectedComps.size(); ++i) {
+  for (size_t i = 0; i < res.edgeBiconnectedComps.size(); ++i) {
     ASSERT_EQ(res.edgeBiconnectedComps[i].size(),
               ebccRes.edgeBiconnectedComps[i].size());
-    for (int j = 0; j < ebccRes.edgeBiconnectedComps[i].size(); ++j) {
+    for (size_t j = 0; j < ebccRes.edgeBiconnectedComps[i].size(); ++j) {
       ASSERT_EQ(res.edgeBiconnectedComps[i][j],
                 ebccRes.edgeBiconnectedComps[i][j]);
     }
   }
   ASSERT_EQ(res.verticeBiconnectedComps.size(),
             vbccRes.verticeBiconnectedComps.size());
-  for (int i = 0; i < res.verticeBiconnectedComps.size(); ++i) {
+  for (size_t i = 0; i < res.verticeBiconnectedComps.size(); ++i) {
     ASSERT_EQ(res.verticeBiconnectedComps[i].size(),
               vbccRes.verticeBiconnectedComps[i].size());
-    for (int j = 0; j < vbccRes.verticeBiconnectedComps[i].size(); ++j) {
+    for (size_t j = 0; j < vbccRes.verticeBiconnectedComps[i].size(); ++j) {
       ASSERT_EQ(res.verticeBiconnectedComps[i][j],
                 vbccRes.verticeBiconnectedComps[i][j]);
     }

--- a/test/TopologicalSortTest.cpp
+++ b/test/TopologicalSortTest.cpp
@@ -96,7 +96,7 @@ TEST(TopologicalSortTest, test_3) {
 
   // check topological order of nodes
   std::unordered_map<CXXGraph::id_t, int> nodeToOrder;
-  for (int i = 0; i < res.nodesInTopoOrder.size(); ++i) {
+  for (size_t i = 0; i < res.nodesInTopoOrder.size(); ++i) {
     nodeToOrder[res.nodesInTopoOrder[i].getId()] = i;
   }
 


### PR DESCRIPTION
Adding `Wall` and `Wextra` flags to the compilation of tests a lot of warnings popped out. This PR fixes them.
I think that this might also fix issue #311.
