### PR TITLE
Fixes #519: Correct invalid labeler.yml file for actions/labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,22 +1,19 @@
-# Add 'repo' label to any root file changes
+# Add 'repo' label to any changes in root files
 repo:
-- owner:SunHappyboy
-  name:CXXGraph
-labels:
-  -name:bug
-   color:ffb4b4
+  - '*'
+
 # Add 'test' label to any change to *.spec.js files within the source dir
 test:
-- test/**
+  - test/**
 
 # Add 'automated workflows' label to any change to workflows files
 automated workflows:
-- .github/workflows//**
+  - .github/workflows/**
 
 # Add 'core` label to any change to include files
 core:
-- include/**
+  - include/**
 
 # Add 'documentation` label to any change to docs files
 documentation:
-- docs/**
+  - docs/**


### PR DESCRIPTION
This Pull Request fixes the incorrect configuration of the **.github/labeler.yml** file, which caused the actions/labeler@v5 action to fail in the CI pipeline.

In the previous version, the repo: label was incorrectly defined as a YAML object instead of a list of file patterns, resulting in errors like:


**Error: found unexpected type for label 'repo' (should be array of config options)**
