### PR TITLE
Add success flag for addEdge

### DIFF
--- a/include/CXXGraph/Graph/Graph_decl.h
+++ b/include/CXXGraph/Graph/Graph_decl.h
@@ -170,9 +170,10 @@ class Graph {
    * Note: No Thread Safe
    *
    * @param edge The Edge to insert
+   * @returns True if the edge was successfully added to the graph
    *
    */
-  virtual void addEdge(const Edge<T> *edge);
+  virtual bool addEdge(const Edge<T> *edge);
 
   /**
    * \brief

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -70,11 +70,15 @@ void Graph<T>::setEdgeSet(const T_EdgeSet<T> &edgeSet) {
 }
 
 template <typename T>
-void Graph<T>::addEdge(const Edge<T> *edge) {
+bool Graph<T>::addEdge(const Edge<T> *edge) {
   shared<const Edge<T>> edge_shared;
 
-  bool is_directed = edge->isDirected().value_or(false);
-  bool is_weighted = edge->isWeighted().value_or(false);
+  if(!edge->isDirected() || !edge->isWeighted()) {
+    return false;
+  }
+
+  bool is_directed = edge->isDirected().value();
+  bool is_weighted = edge->isWeighted().value();
 
   if (is_directed) {
     if (is_weighted) {
@@ -93,6 +97,8 @@ void Graph<T>::addEdge(const Edge<T> *edge) {
   }
 
   addEdge(edge_shared);
+
+  return true;
 }
 
 template <typename T>

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -210,6 +210,24 @@ TEST(GraphTest, RawAddEdge_3) {
   ASSERT_FALSE(graph.isUndirectedGraph());
 }
 
+TEST(GraphTest, AddEdge_ReturnsFailureFlag) {
+  CXXGraph::Node<int> node1("1", 1);
+  CXXGraph::Node<int> node2("2", 1);
+  CXXGraph::Node<int> node3("3", 1);
+
+  CXXGraph::Edge<int> edge1(1, node1, node2);
+  CXXGraph::Edge<int> edge2(2, node1, node3);
+  CXXGraph::Edge<int> edge3(3, node2, node3);
+
+  CXXGraph::Graph<int> graph;
+
+  ASSERT_FALSE(graph.addEdge(&edge1));
+  ASSERT_FALSE(graph.addEdge(&edge2));
+  ASSERT_FALSE(graph.addEdge(&edge3));
+
+  ASSERT_EQ(graph.getEdgeSet().size(), 0);
+}
+
 TEST(GraphTest, AddEdgeWeight_raw) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 1);


### PR DESCRIPTION
Fixes Issue #521. 

If either `std::optional`s are not set, return false, else continue normally. Adds this test as well. 