### PR TITLE
Refactor addEdge - removed duplicate insert

### DIFF
--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -97,7 +97,10 @@ void Graph<T>::addEdge(const Edge<T> *edge) {
 
 template <typename T>
 void Graph<T>::addEdge(shared<const Edge<T>> edge) {
-  this->edgeSet.insert(edge);
+  auto [it, inserted] = edgeSet.insert(edge);
+  if (!inserted) {
+      return;
+  }
 
   auto &[from, to] = edge->getNodePair();
 


### PR DESCRIPTION
Title:
Fix duplicated insert in addEdge function (#533)

Related Issue:
Closes #533

Description:
This PR fixes a duplicated insert call in the addEdge function of Graph<T>. Previously, the function was calling edgeSet.insert(edge) twice, which is unnecessary.

The changes include:

Removed the redundant edgeSet.insert(edge) call.

Refactored duplicate detection to use the return value of insert() for cleaner and more efficient code.

Maintained proper updates to cached adjacency lists for both directed and undirected edges.

Code Reference:
Original line: [Graph_impl.hpp#L105-L105](https://github.com/ZigRazor/CXXGraph/blob/15eaeab857b10e239140f36e6bdc4bdb6d21ba3d/include/CXXGraph/Graph/Graph_impl.hpp#L105C2-L105C30)