### PR TITLE
Use `try_emplace` to avoid multipe look-up

### DIFF
--- a/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
@@ -110,10 +110,8 @@ template <typename T>
 std::shared_ptr<Record<T>> CoordinatedPartitionState<T>::getRecord(
     CXXGraph::id_t x) {
   std::lock_guard<std::mutex> lock(*record_map_mutex);
-  if (record_map.find(x) == record_map.end()) {
-    record_map[x] = std::make_shared<CoordinatedRecord<T>>();
-  }
-  return record_map.at(x);
+  return record_map.try_emplace(x, std::make_shared<CoordinatedRecord<T>>())
+      .first->second;
 }
 
 template <typename T>


### PR DESCRIPTION
This code can be simplified and optimized by using using [`try_emplace`](https://en.cppreference.com/w/cpp/container/map/try_emplace.html). Multiple look-up is no longer performed.