### PR TITLE
Fixes #530, by replacement of algorithm in HDRF and addition of member variable in Record

### DIFF
--- a/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
@@ -116,12 +116,18 @@ bool CoordinatedRecord<T>::hasReplicaInPartition(const int m) const {
 }
 template <typename T>
 bool CoordinatedRecord<T>::getLock() {
-  return lock->try_lock();
+  owns_lock = lock->try_lock();
+  return owns_lock;
 }
+
 template <typename T>
 bool CoordinatedRecord<T>::releaseLock() {
-  lock->unlock();
-  return true;
+  if (owns_lock) {
+    lock->unlock();
+    owns_lock = false;
+    return true;
+  }
+  return false;
 }
 template <typename T>
 int CoordinatedRecord<T>::getReplicas() const {

--- a/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
@@ -116,7 +116,7 @@ bool CoordinatedRecord<T>::hasReplicaInPartition(const int m) const {
 }
 template <typename T>
 bool CoordinatedRecord<T>::getLock() {
-  owns_lock = lock->try_lock();
+  this->owns_lock = lock->try_lock();
   return owns_lock;
 }
 
@@ -124,7 +124,7 @@ template <typename T>
 bool CoordinatedRecord<T>::releaseLock() {
   if (owns_lock) {
     lock->unlock();
-    owns_lock = false;
+    this->owns_lock = false;
     return true;
   }
   return false;

--- a/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
@@ -117,12 +117,12 @@ bool CoordinatedRecord<T>::hasReplicaInPartition(const int m) const {
 template <typename T>
 bool CoordinatedRecord<T>::getLock() {
   this->owns_lock = lock->try_lock();
-  return owns_lock;
+  return this->owns_lock;
 }
 
 template <typename T>
 bool CoordinatedRecord<T>::releaseLock() {
-  if (owns_lock) {
+  if (this->owns_lock) {
     lock->unlock();
     this->owns_lock = false;
     return true;

--- a/include/CXXGraph/Partitioning/Record.hpp
+++ b/include/CXXGraph/Partitioning/Record.hpp
@@ -28,6 +28,8 @@ namespace CXXGraph {
 namespace Partitioning {
 template <typename T>
 class Record {
+  protected:
+  bool owns_lock = false;
  public:
   virtual ~Record() = default;
 


### PR DESCRIPTION
### Summary of changes
- Replaced the dangerous lock algorithm in HDRF with a safer backoff algorithm
- Introudced owns_lock member variable to Record class to stop the unlocking of unowned mutexes 

### Why
- The recursive call of the lock algorithm of HDRF is potentially dangerous
- The unlocking of unowned mutexes was caused by the releaseLock() function, as there was no check to see it was owned or not

### Related issue
- Fixes #530 with the introduction of the mentioned safety features  