### PR TITLE
Use `empty()` to resolve `readability-container-size-empty`

### DIFF
--- a/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
@@ -140,7 +140,7 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T>& source,
     result.errorMessage = "";
     result.result = dist[*target_node_it];
     std::string id = target.getUserId();
-    while (parent[id] != "") {
+    while (!parent[id].empty()) {
       result.path.push_back(id);
       id = parent[id];
     }
@@ -288,7 +288,7 @@ const DijkstraResult Graph<T>::dijkstra_deterministic(
     result.errorMessage = "";
     result.result = dist[*target_node_it];
     std::string id = target.getUserId();
-    while (parent[id] != "") {
+    while (!parent[id].empty()) {
       result.path.push_back(id);
       id = parent[id];
     }
@@ -444,7 +444,7 @@ const DijkstraResult Graph<T>::dijkstra_deterministic2(
     result.errorMessage = "";
     result.result = dist[*target_node_it];
     std::string id = target.getUserId();
-    while (parent[id] != "") {
+    while (!parent[id].empty()) {
       result.path.push_back(id);
       id = parent[id];
     }
@@ -591,7 +591,7 @@ const DijkstraResult Graph<T>::criticalpath_deterministic(
     result.errorMessage = "";
     result.result = dist[*target_node_it];
     std::string id = target.getUserId();
-    while (parent[id] != "") {
+    while (!parent[id].empty()) {
       result.path.push_back(id);
       id = parent[id];
     }

--- a/include/CXXGraph/Graph/Algorithm/EulerianPath_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/EulerianPath_impl.hpp
@@ -47,7 +47,7 @@ std::shared_ptr<std::vector<Node<T>>> Graph<T>::eulerianPath() const {
   auto currentNode = *(firstNodeIt);
   currentPath.push_back(currentNode);
 
-  while (currentPath.size() > 0) {
+  while (!currentPath.empty()) {
     auto &edges = cachedAdjListOut->at(currentNode);
     // we keep removing the edges that
     // have been traversed from the adjacency list

--- a/include/CXXGraph/Graph/Algorithm/Kosaraju_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Kosaraju_impl.hpp
@@ -109,7 +109,7 @@ SCCResult<T> Graph<T>::kosaraju() const {
         };
 
     int sccLabel = 0;
-    while (st.size() != 0) {
+    while (!st.empty()) {
       auto rem = st.top();
       st.pop();
       if (visited[rem->getId()] == false) {


### PR DESCRIPTION
This PR resolved the [`readability-container-size-empty`](https://clang.llvm.org/extra/clang-tidy/checks/readability/container-size-empty.html) warning.