### PR TITLE
Resolve `cppcoreguidelines-explicit-virtual-functions`

### DIFF
--- a/include/CXXGraph/Edge/DirectedEdge_decl.h
+++ b/include/CXXGraph/Edge/DirectedEdge_decl.h
@@ -52,7 +52,7 @@ class DirectedEdge : public Edge<T> {
       const std::string &userId,
       const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair);
   DirectedEdge(const Edge<T> &edge);
-  virtual ~DirectedEdge() = default;
+  ~DirectedEdge() override = default;
   const Node<T> &getFrom() const;
   const Node<T> &getTo() const;
   const std::optional<bool> isDirected() const override;

--- a/include/CXXGraph/Edge/DirectedWeightedEdge_decl.h
+++ b/include/CXXGraph/Edge/DirectedWeightedEdge_decl.h
@@ -62,7 +62,7 @@ class DirectedWeightedEdge : public DirectedEdge<T>, public Weighted {
   DirectedWeightedEdge(const DirectedEdge<T> &edge);
   DirectedWeightedEdge(const Edge<T> &edge);
   DirectedWeightedEdge(const UndirectedWeightedEdge<T> &edge);
-  virtual ~DirectedWeightedEdge() = default;
+  ~DirectedWeightedEdge() override = default;
   const std::optional<bool> isWeighted() const override;
   // operator
   explicit operator UndirectedWeightedEdge<T>() const {

--- a/include/CXXGraph/Edge/UndirectedEdge_decl.h
+++ b/include/CXXGraph/Edge/UndirectedEdge_decl.h
@@ -51,7 +51,7 @@ class UndirectedEdge : public Edge<T> {
       const std::string &userId,
       const std::pair<shared<const Node<T>>, shared<const Node<T>>> &nodepair);
   UndirectedEdge(const Edge<T> &edge);
-  virtual ~UndirectedEdge() = default;
+  ~UndirectedEdge() override = default;
   const Node<T> &getNode1() const;
   const Node<T> &getNode2() const;
   const std::optional<bool> isDirected() const override;

--- a/include/CXXGraph/Edge/UndirectedWeightedEdge_decl.h
+++ b/include/CXXGraph/Edge/UndirectedWeightedEdge_decl.h
@@ -64,7 +64,7 @@ class UndirectedWeightedEdge : public UndirectedEdge<T>, public Weighted {
   UndirectedWeightedEdge(const UndirectedEdge<T> &edge);
   UndirectedWeightedEdge(const Edge<T> &edge);
   UndirectedWeightedEdge(const DirectedWeightedEdge<T> &edge);
-  virtual ~UndirectedWeightedEdge() = default;
+  ~UndirectedWeightedEdge() override = default;
   const std::optional<bool> isWeighted() const override;
   // operator
   explicit operator DirectedWeightedEdge<T>() const {

--- a/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
@@ -62,7 +62,7 @@ class CoordinatedPartitionState : public PartitionState<T> {
   // DatWriter out; //to print the final partition of each edge
  public:
   CoordinatedPartitionState(const Globals &G);
-  ~CoordinatedPartitionState();
+  ~CoordinatedPartitionState() override;
 
   std::shared_ptr<Record<T>> getRecord(CXXGraph::id_t x) override;
   int getMachineLoad(const int m) const override;

--- a/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
@@ -39,7 +39,7 @@ class CoordinatedRecord : public Record<T> {
 
  public:
   CoordinatedRecord();
-  ~CoordinatedRecord();
+  ~CoordinatedRecord() override;
 
   const std::set<int> &getPartitions() const override;
   void addPartition(const int m) override;

--- a/include/CXXGraph/Partitioning/EBV.hpp
+++ b/include/CXXGraph/Partitioning/EBV.hpp
@@ -55,7 +55,7 @@ class EBV : public PartitionStrategy<T> {
 
  public:
   explicit EBV(const Globals &G);
-  ~EBV();
+  ~EBV() override;
 
   void performStep(shared<const Edge<T>> e,
                    shared<PartitionState<T>> Sstate) override;

--- a/include/CXXGraph/Partitioning/EdgeBalancedVertexCut.hpp
+++ b/include/CXXGraph/Partitioning/EdgeBalancedVertexCut.hpp
@@ -53,7 +53,7 @@ class EdgeBalancedVertexCut : public PartitionStrategy<T> {
 
  public:
   explicit EdgeBalancedVertexCut(const Globals &G);
-  ~EdgeBalancedVertexCut();
+  ~EdgeBalancedVertexCut() override;
 
   void performStep(shared<const Edge<T>> e,
                    shared<PartitionState<T>> Sstate) override;

--- a/include/CXXGraph/Partitioning/GreedyVertexCut.hpp
+++ b/include/CXXGraph/Partitioning/GreedyVertexCut.hpp
@@ -55,7 +55,7 @@ class GreedyVertexCut : public PartitionStrategy<T> {
 
  public:
   explicit GreedyVertexCut(const Globals &G);
-  ~GreedyVertexCut();
+  ~GreedyVertexCut() override;
 
   void performStep(shared<const Edge<T>> e,
                    shared<PartitionState<T>> Sstate) override;

--- a/include/CXXGraph/Partitioning/HDRF.hpp
+++ b/include/CXXGraph/Partitioning/HDRF.hpp
@@ -55,7 +55,7 @@ class HDRF : public PartitionStrategy<T> {
 
  public:
   explicit HDRF(const Globals &G);
-  ~HDRF();
+  ~HDRF() override;
 
   void performStep(shared<const Edge<T>> e,
                    shared<PartitionState<T>> Sstate) override;

--- a/include/CXXGraph/Partitioning/Partition.hpp
+++ b/include/CXXGraph/Partitioning/Partition.hpp
@@ -55,7 +55,7 @@ class Partition : public Graph<T> {
   explicit Partition(const CXXGraph::id_t partitionId);
   explicit Partition(const T_EdgeSet<T> &edgeSet);
   Partition(const CXXGraph::id_t partitionId, const T_EdgeSet<T> &edgeSet);
-  ~Partition() = default;
+  ~Partition() override = default;
   /**
    * @brief Get the Partition ID
    *

--- a/include/CXXGraph/Partitioning/PartitionerThread.hpp
+++ b/include/CXXGraph/Partitioning/PartitionerThread.hpp
@@ -43,7 +43,7 @@ class PartitionerThread : public Runnable {
   PartitionerThread(std::vector<shared<const Edge<T>>> &list,
                     shared<PartitionState<T>> state,
                     shared<PartitionStrategy<T>> algorithm);
-  ~PartitionerThread();
+  ~PartitionerThread() override;
 
   void run() override;
 

--- a/include/CXXGraph/Partitioning/WeightBalancedLibra.hpp
+++ b/include/CXXGraph/Partitioning/WeightBalancedLibra.hpp
@@ -48,7 +48,7 @@ class WeightBalancedLibra : public PartitionStrategy<T> {
   explicit WeightBalancedLibra(
       const Globals &G, double _weight_sum_bound,
       std::unordered_map<std::size_t, int> &&_vertices_degrees);
-  ~WeightBalancedLibra();
+  ~WeightBalancedLibra() override;
 
   void performStep(shared<const Edge<T>> e,
                    shared<PartitionState<T>> Sstate) override;


### PR DESCRIPTION
This PR resolves [`cppcoreguidelines-explicit-virtual-functions`](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/explicit-virtual-functions.html).

Cf. also: [_CppCoreGuidelines_](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final).
