### PR TITLE
Disable `clang-format` on Windows includes in `SecureRandom.hpp`

### DIFF
--- a/include/CXXGraph/Utility/SecureRandom.hpp
+++ b/include/CXXGraph/Utility/SecureRandom.hpp
@@ -4,8 +4,10 @@
 #include <stdexcept>
 
 #if defined(_WIN32) || defined(_WIN64)
+// clang-format off
 #include <windows.h>
 #include <bcrypt.h>
+// clang-format on
 #ifndef STATUS_SUCCESS
 #define STATUS_SUCCESS ((NTSTATUS)0x00000000L)
 #endif


### PR DESCRIPTION
This fixes [failing CI](https://github.com/ZigRazor/CXXGraph/actions/runs/18321126371/job/52174174939?pr=546).