### PR TITLE
Resolve cmake mis-matching arguments warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ else ()
 			-fsanitize=leak
 		)
 	endif(SANITIZE)
-endif(NOT MSVC)
+endif(MSVC)
 
 # set up CPM.cmake
 if(CPM_SOURCE_CACHE)


### PR DESCRIPTION
When _configuring_ CMake, the output contains warning like:
```
  A logical block opening on the line

    /home/runner/work/CXXGraph/CXXGraph/CMakeLists.txt:22 (if)

  closes on the line

    /home/runner/work/CXXGraph/CXXGraph/CMakeLists.txt:36 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
This PR removes it.