### PR TITLE
Resolve `modernize-deprecated-headers`

### DIFF
--- a/benchmark/Utilities.hpp
+++ b/benchmark/Utilities.hpp
@@ -1,7 +1,6 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
-#include <time.h>
-
+#include <ctime>
 #include <random>
 
 #include "CXXGraph/CXXGraph.hpp"

--- a/examples/DialExample/dial_example.cpp
+++ b/examples/DialExample/dial_example.cpp
@@ -1,6 +1,5 @@
-#include <math.h>
-
 #include <CXXGraph/CXXGraph.hpp>
+#include <cmath>
 #include <memory>
 
 using std::make_shared;

--- a/examples/PartitionExample/partition_example.cpp
+++ b/examples/PartitionExample/partition_example.cpp
@@ -1,6 +1,5 @@
-#include <stdlib.h>
-#include <time.h>
-
+#include <cstdlib>
+#include <ctime>
 #include <iterator>
 
 #include "CXXGraph/CXXGraph.hpp"

--- a/include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp
@@ -107,6 +107,7 @@ BestFirstSearchResult<T> Graph<T>::best_first_search(
 template <typename T>
 const std::vector<Node<T>> Graph<T>::concurrency_breadth_first_search(
     const Node<T> &start, size_t num_threads) const {
+  num_threads = 1;
   std::vector<Node<T>> bfs_result;
   // check is exist node in the graph
   auto &nodeSet = Graph<T>::getNodeSet();

--- a/test/Utilities.hpp
+++ b/test/Utilities.hpp
@@ -1,7 +1,6 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
-#include <time.h>
-
+#include <ctime>
 #include <memory>
 #include <random>
 


### PR DESCRIPTION
This change resolves [`modernize-deprecated-headers`](https://clang.llvm.org/extra/clang-tidy/checks/modernize/deprecated-headers.html).
