### PR TITLE
Simplify usage of `std::optional<bool>`

### DIFF
--- a/include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp
@@ -73,7 +73,7 @@ const BellmanFordResult Graph<T>::bellmanford(const Node<T> &source,
     // each relaxation
     for (const auto &edge : edgeSet) {
       auto elem = edge->getNodePair();
-      if (edge->isWeighted().has_value() && edge->isWeighted().value()) {
+      if (edge->isWeighted().value_or(false)) {
         auto edge_weight =
             (std::dynamic_pointer_cast<const Weighted>(edge))->getWeight();
         if (dist[elem.first] + edge_weight < dist[elem.second])

--- a/include/CXXGraph/Graph/Algorithm/Boruvka_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Boruvka_impl.hpp
@@ -53,7 +53,7 @@ const MstResult Graph<T>::boruvka() const {
   const auto edgeSet = Graph<T>::getEdgeSet();
   std::unordered_map<CXXGraph::id_t, double> edgeWeight;
   for (const auto &edge : edgeSet) {
-    if (edge->isWeighted().has_value() && edge->isWeighted().value())
+    if (edge->isWeighted().value_or(false))
       edgeWeight[edge->getId()] =
           (std::dynamic_pointer_cast<const Weighted>(edge))->getWeight();
     else {
@@ -148,7 +148,7 @@ const MstResult Graph<T>::boruvka_deterministic() const {
   const auto edgeSet = Graph<T>::getEdgeSet();
   std::unordered_map<CXXGraph::id_t, double> edgeWeight;
   for (const auto &edge : edgeSet) {
-    if (edge->isWeighted().has_value() && edge->isWeighted().value())
+    if (edge->isWeighted().value_or(false))
       edgeWeight[edge->getId()] =
           (std::dynamic_pointer_cast<const Weighted>(edge))->getWeight();
     else {

--- a/include/CXXGraph/Graph/Algorithm/Dial_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dial_impl.hpp
@@ -87,15 +87,12 @@ const DialResult Graph<T>::dial(const Node<T> &source, int maxWeight) const {
     for (const auto &i : (*cachedAdjListOut)[u]) {
       auto v = i.first;
       int weight = 0;
-      if (i.second->isWeighted().has_value() &&
-          i.second->isWeighted().value()) {
-        if (i.second->isDirected().has_value() &&
-            i.second->isDirected().value()) {
+      if (i.second->isWeighted().value_or(false)) {
+        if (i.second->isDirected().value_or(false)) {
           shared<const DirectedWeightedEdge<T>> dw_edge =
               std::static_pointer_cast<const DirectedWeightedEdge<T>>(i.second);
           weight = (int)dw_edge->getWeight();
-        } else if (i.second->isDirected().has_value() &&
-                   !i.second->isDirected().value()) {
+        } else if (i.second->isDirected() == false) {
           shared<const UndirectedWeightedEdge<T>> udw_edge =
               std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
                   i.second);

--- a/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
@@ -91,10 +91,8 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T>& source,
     if (cachedAdjListOut->find(currentNode) != cachedAdjListOut->end()) {
       for (const auto& elem : cachedAdjListOut->at(currentNode)) {
         // minimizing distances
-        if (elem.second->isWeighted().has_value() &&
-            elem.second->isWeighted().value()) {
-          if (elem.second->isDirected().has_value() &&
-              elem.second->isDirected().value()) {
+        if (elem.second->isWeighted().value_or(false)) {
+          if (elem.second->isDirected().value_or(false)) {
             shared<const DirectedWeightedEdge<T>> dw_edge =
                 std::static_pointer_cast<const DirectedWeightedEdge<T>>(
                     elem.second);
@@ -107,8 +105,7 @@ const DijkstraResult Graph<T>::dijkstra(const Node<T>& source,
               parent[elem.first.get()->getUserId()] =
                   currentNode.get()->getUserId();
             }
-          } else if (elem.second->isDirected().has_value() &&
-                     !elem.second->isDirected().value()) {
+          } else if (elem.second->isDirected() == false) {
             shared<const UndirectedWeightedEdge<T>> udw_edge =
                 std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
                     elem.second);
@@ -235,10 +232,8 @@ const DijkstraResult Graph<T>::dijkstra_deterministic(
     if (cachedAdjListOut->find(currentNode) != cachedAdjListOut->end()) {
       for (const auto& elem : cachedAdjListOut->at(currentNode)) {
         // minimizing distances
-        if (elem.second->isWeighted().has_value() &&
-            elem.second->isWeighted().value()) {
-          if (elem.second->isDirected().has_value() &&
-              elem.second->isDirected().value()) {
+        if (elem.second->isWeighted().value_or(false)) {
+          if (elem.second->isDirected().value_or(false)) {
             shared<const DirectedWeightedEdge<T>> dw_edge =
                 std::static_pointer_cast<const DirectedWeightedEdge<T>>(
                     elem.second);
@@ -253,8 +248,7 @@ const DijkstraResult Graph<T>::dijkstra_deterministic(
               parent[elem.first.get()->getUserId()] =
                   currentNode.get()->getUserId();
             }
-          } else if (elem.second->isDirected().has_value() &&
-                     !elem.second->isDirected().value()) {
+          } else if (!elem.second->isDirected() == false) {
             shared<const UndirectedWeightedEdge<T>> udw_edge =
                 std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
                     elem.second);
@@ -391,10 +385,8 @@ const DijkstraResult Graph<T>::dijkstra_deterministic2(
     if (cachedAdjListOut->find(currentNode) != cachedAdjListOut->end()) {
       for (const auto& elem : cachedAdjListOut->at(currentNode)) {
         // minimizing distances
-        if (elem.second->isWeighted().has_value() &&
-            elem.second->isWeighted().value()) {
-          if (elem.second->isDirected().has_value() &&
-              elem.second->isDirected().value()) {
+        if (elem.second->isWeighted().value_or(false)) {
+          if (elem.second->isDirected().value_or(false)) {
             shared<const DirectedWeightedEdge<T>> dw_edge =
                 std::static_pointer_cast<const DirectedWeightedEdge<T>>(
                     elem.second);
@@ -409,8 +401,7 @@ const DijkstraResult Graph<T>::dijkstra_deterministic2(
               parent[elem.first.get()->getUserId()] =
                   currentNode.get()->getUserId();
             }
-          } else if (elem.second->isDirected().has_value() &&
-                     !elem.second->isDirected().value()) {
+          } else if (!elem.second->isDirected() == false) {
             shared<const UndirectedWeightedEdge<T>> udw_edge =
                 std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
                     elem.second);
@@ -538,10 +529,8 @@ const DijkstraResult Graph<T>::criticalpath_deterministic(
     if (cachedAdjListOut->find(currentNode) != cachedAdjListOut->end()) {
       for (const auto& elem : cachedAdjListOut->at(currentNode)) {
         // minimizing distances
-        if (elem.second->isWeighted().has_value() &&
-            elem.second->isWeighted().value()) {
-          if (elem.second->isDirected().has_value() &&
-              elem.second->isDirected().value()) {
+        if (elem.second->isWeighted().value_or(false)) {
+          if (elem.second->isDirected().value_or(false)) {
             shared<const DirectedWeightedEdge<T>> dw_edge =
                 std::static_pointer_cast<const DirectedWeightedEdge<T>>(
                     elem.second);
@@ -556,8 +545,7 @@ const DijkstraResult Graph<T>::criticalpath_deterministic(
               parent[elem.first.get()->getUserId()] =
                   currentNode.get()->getUserId();
             }
-          } else if (elem.second->isDirected().has_value() &&
-                     !elem.second->isDirected().value()) {
+          } else if (elem.second->isDirected() == false) {
             shared<const UndirectedWeightedEdge<T>> udw_edge =
                 std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
                     elem.second);

--- a/include/CXXGraph/Graph/Algorithm/FloydWarshall_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/FloydWarshall_impl.hpp
@@ -51,7 +51,7 @@ const FWResult Graph<T>::floydWarshall() const {
   // connected by edges
   for (const auto &edge : edgeSet) {
     const auto &elem = edge->getNodePair();
-    if (edge->isWeighted().has_value() && edge->isWeighted().value()) {
+    if (edge->isWeighted().value_or(false)) {
       auto edgeWeight =
           (std::dynamic_pointer_cast<const Weighted>(edge))->getWeight();
       auto key =

--- a/include/CXXGraph/Graph/Algorithm/Kruskal_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Kruskal_impl.hpp
@@ -47,7 +47,7 @@ const MstResult Graph<T>::kruskal() const {
                       std::greater<std::pair<double, shared<const Edge<T>>>>>
       sortedEdges;
   for (const auto &edge : edgeSet) {
-    if (edge->isWeighted().has_value() && edge->isWeighted().value()) {
+    if (edge->isWeighted().value_or(false)) {
       auto weight =
           (std::dynamic_pointer_cast<const Weighted>(edge))->getWeight();
       sortedEdges.push(std::make_pair(weight, edge));

--- a/include/CXXGraph/Graph/Algorithm/Prim_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Prim_impl.hpp
@@ -86,8 +86,7 @@ const MstResult Graph<T>::prim() const {
     if (cachedAdjListOut->find(currentNode) != cachedAdjListOut->end()) {
       for (const auto &elem : cachedAdjListOut->at(currentNode)) {
         // minimizing distances
-        if (elem.second->isWeighted().has_value() &&
-            elem.second->isWeighted().value()) {
+        if (elem.second->isWeighted().value_or(false)) {
           shared<const UndirectedWeightedEdge<T>> udw_edge =
               std::static_pointer_cast<const UndirectedWeightedEdge<T>>(
                   elem.second);

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -971,30 +971,20 @@ Graph<T>::inOrOutEdges(shared<const Node<T>> node) const {
   return inOrOutEdges;
 }
 
+inline const auto isEdgeDirected = [](const auto &edge) {
+  return edge->isDirected().value_or(false);
+};
+
 template <typename T>
 bool Graph<T>::isDirectedGraph() const {
-  auto edgeSet = getEdgeSet();
-  for (const auto &edge : edgeSet) {
-    if (!(edge->isDirected().has_value() && edge->isDirected().value())) {
-      // Found Undirected Edge
-      return false;
-    }
-  }
-  // No Undirected Edge
-  return true;
+  const auto edgeSet = getEdgeSet();
+  return std::all_of(edgeSet.cbegin(), edgeSet.cend(), isEdgeDirected);
 }
 
 template <typename T>
 bool Graph<T>::isUndirectedGraph() const {
-  auto edgeSet = Graph<T>::getEdgeSet();
-  for (const auto &edge : edgeSet) {
-    if ((edge->isDirected().has_value() && edge->isDirected().value())) {
-      // Found Directed Edge
-      return false;
-    }
-  }
-  // No Directed Edge
-  return true;
+  const auto edgeSet = Graph<T>::getEdgeSet();
+  return std::none_of(edgeSet.cbegin(), edgeSet.cend(), isEdgeDirected);
 }
 
 template <typename T>

--- a/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
@@ -145,7 +145,7 @@ void CoordinatedPartitionState<T>::incrementMachineWeight(
     const int m, shared<const Edge<T>> e) {
   std::lock_guard<std::mutex> lock(*machines_weight_edges_mutex);
   double edge_weight = CXXGraph::NEGLIGIBLE_WEIGHT;
-  if (e->isWeighted().has_value() && e->isWeighted().value()) {
+  if (e->isWeighted().value_or(false)) {
     edge_weight = (std::dynamic_pointer_cast<const Weighted>(e))->getWeight();
   }
   machines_weight_edges[m] = machines_weight_edges[m] + edge_weight;

--- a/include/CXXGraph/Partitioning/Partition.hpp
+++ b/include/CXXGraph/Partitioning/Partition.hpp
@@ -332,27 +332,19 @@ std::ostream &operator<<(std::ostream &os, const Partition<T> &partition) {
     if (!(*it)->isDirected().has_value() && !(*it)->isWeighted().has_value()) {
       // Edge Case
       os << **it << "\n";
-    } else if (((*it)->isDirected().has_value() &&
-                (*it)->isDirected().value()) &&
-               ((*it)->isWeighted().has_value() &&
-                (*it)->isWeighted().value())) {
+    } else if ((*it)->isDirected().value_or(false) &&
+               ((*it)->isWeighted().value_or(false))) {
       os << *std::static_pointer_cast<const DirectedWeightedEdge<T>>(*it)
          << "\n";
-    } else if (((*it)->isDirected().has_value() &&
-                (*it)->isDirected().value()) &&
-               !((*it)->isWeighted().has_value() &&
-                 (*it)->isWeighted().value())) {
+    } else if ((*it)->isDirected().value_or(false) &&
+               !((*it)->isWeighted().value_or(false))) {
       os << *std::static_pointer_cast<const DirectedEdge<T>>(*it) << "\n";
-    } else if (!((*it)->isDirected().has_value() &&
-                 (*it)->isDirected().value()) &&
-               ((*it)->isWeighted().has_value() &&
-                (*it)->isWeighted().value())) {
+    } else if (!((*it)->isDirected().value_or(false)) &&
+               ((*it)->isWeighted().value_or(false))) {
       os << *std::static_pointer_cast<const UndirectedWeightedEdge<T>>(*it)
          << "\n";
-    } else if (!((*it)->isDirected().has_value() &&
-                 (*it)->isDirected().value()) &&
-               !((*it)->isWeighted().has_value() &&
-                 (*it)->isWeighted().value())) {
+    } else if (!((*it)->isDirected().value_or(false)) &&
+               !((*it)->isWeighted().value_or(false))) {
       os << *std::static_pointer_cast<const UndirectedEdge<T>>(*it) << "\n";
     } else {
       // Should never happens

--- a/include/CXXGraph/Partitioning/Partitioner.hpp
+++ b/include/CXXGraph/Partitioning/Partitioner.hpp
@@ -99,7 +99,7 @@ Partitioner<T>::Partitioner(shared<const T_EdgeSet<T>> dataset, Globals &G)
     double weight_sum = 0.0;
     for (const auto &edge_it : *(this->dataset)) {
       weight_sum +=
-          (edge_it->isWeighted().has_value() && edge_it->isWeighted().value())
+          (edge_it->isWeighted().value_or(false))
               ? std::dynamic_pointer_cast<const Weighted>(edge_it)->getWeight()
               : CXXGraph::NEGLIGIBLE_WEIGHT;
     }
@@ -142,7 +142,7 @@ Partitioner<T>::Partitioner(const Partitioner &other) {
     double weight_sum = 0.0;
     for (const auto &edge_it : *(this->dataset)) {
       weight_sum +=
-          (edge_it->isWeighted().has_value() && edge_it->isWeighted().value())
+          (edge_it->isWeighted().value_or(false))
               ? std::dynamic_pointer_cast<const Weighted>(edge_it)->getWeight()
               : CXXGraph::NEGLIGIBLE_WEIGHT;
     }


### PR DESCRIPTION
This change consists of two parts:
- use `std::any_of` and `std::none_of` in `isDirectedGraph()` and `isUndirectedGraph()` respectively,
- simplify the logic of using `std::optional<bool>` by mostly using `.value_or()`.

I decided not to update the test files. My plan is to do in in another PR, so it will be easier to see that these changes do not change the logic.