### PR TITLE
Fix building examples

### DIFF
--- a/examples/DialExample/CMakeLists.txt
+++ b/examples/DialExample/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.9)
-project(DialExample)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -8,10 +7,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES /usr/local/lib ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
 
 add_executable(dial_example dial_example.cpp)
-target_include_directories(dial_example PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
 target_link_libraries(dial_example
-                        pthread
-                        ssl
-                        crypto
-                        z)
+                      ${PROJECT_NAME})

--- a/examples/DijkstraExample/CMakeLists.txt
+++ b/examples/DijkstraExample/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.9)
-project(DijkstraExample)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -8,10 +7,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES /usr/local/lib ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
 
 add_executable(dijkstra_example dijkstra_example.cpp)
-target_include_directories(dijkstra_example PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
 target_link_libraries(dijkstra_example
-                        pthread
-                        ssl
-                        crypto
-                        z)
+                      ${PROJECT_NAME})

--- a/examples/FloydWarshallExample/CMakeLists.txt
+++ b/examples/FloydWarshallExample/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.9)
-project(floydWarshallExample)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -8,10 +7,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES /usr/local/lib ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
 
 add_executable(floyd_warshall floyd_warshall.cpp)
-target_include_directories(floyd_warshall PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
 target_link_libraries(floyd_warshall
-                        pthread
-                        ssl
-                        crypto
-                        z)
+                      ${PROJECT_NAME})

--- a/examples/NetworkDynamicsExample/CMakeLists.txt
+++ b/examples/NetworkDynamicsExample/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.9)
-project(NetworkDynamicsExample)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -8,10 +7,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES /usr/local/lib ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
 
 add_executable(network_dynamics_example network_dynamics_example.cpp)
-target_include_directories(network_dynamics_example PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
 target_link_libraries(network_dynamics_example
-                        pthread
-                        ssl
-                        crypto
-                        z)
+                      ${PROJECT_NAME})

--- a/examples/PartitionExample/CMakeLists.txt
+++ b/examples/PartitionExample/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.9)
-project(PartitionExample)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -8,10 +7,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES /usr/local/lib ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
 
 add_executable(partition_example partition_example.cpp)
-target_include_directories(partition_example PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
 target_link_libraries(partition_example
-                        pthread
-                        ssl
-                        crypto
-                        z)
+                      ${PROJECT_NAME})

--- a/examples/PrimExample/CMakeLists.txt
+++ b/examples/PrimExample/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.9)
-project(PrimExample)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -8,10 +7,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES /usr/local/lib ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
 
 add_executable(prim_example prim_example.cpp)
-target_include_directories(prim_example PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
 target_link_libraries(prim_example
-                        pthread
-                        ssl
-                        crypto
-                        z)
+                      ${PROJECT_NAME})


### PR DESCRIPTION
After #553, CodeQL is [failing](https://github.com/ZigRazor/CXXGraph/actions/runs/18966552363/job/54164308564).

This is an attempt to fix it.

It turned out that linking `pthread`, `ssl`, `crypto` and `z` is no loner needed, so I removed it.
