### PR TITLE
Add missing include statements to standard headers

### DIFF
--- a/benchmark/BFS_BM.cpp
+++ b/benchmark/BFS_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/BellmanFord_BM.cpp
+++ b/benchmark/BellmanFord_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Boruvka_BM.cpp
+++ b/benchmark/Boruvka_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Connectivity_BM.cpp
+++ b/benchmark/Connectivity_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/CycleCheck_BM.cpp
+++ b/benchmark/CycleCheck_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/DFS_BM.cpp
+++ b/benchmark/DFS_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Dial_BM.cpp
+++ b/benchmark/Dial_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Dijkstra_BM.cpp
+++ b/benchmark/Dijkstra_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/EulerPath_BM.cpp
+++ b/benchmark/EulerPath_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/FordFulkerson_BM.cpp
+++ b/benchmark/FordFulkerson_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/GraphSlicing_BM.cpp
+++ b/benchmark/GraphSlicing_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Graph_BM.cpp
+++ b/benchmark/Graph_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Kosaraju_BM.cpp
+++ b/benchmark/Kosaraju_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Kruskal_BM.cpp
+++ b/benchmark/Kruskal_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Partition_BM.cpp
+++ b/benchmark/Partition_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Prim_BM.cpp
+++ b/benchmark/Prim_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/TopologicalSort_BM.cpp
+++ b/benchmark/TopologicalSort_BM.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "Utilities.hpp"
 

--- a/benchmark/Utilities.hpp
+++ b/benchmark/Utilities.hpp
@@ -1,7 +1,9 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
 #include <ctime>
+#include <map>
 #include <random>
+#include <string>
 
 #include "CXXGraph/CXXGraph.hpp"
 

--- a/examples/DialExample/dial_example.cpp
+++ b/examples/DialExample/dial_example.cpp
@@ -1,6 +1,8 @@
 #include <CXXGraph/CXXGraph.hpp>
 #include <cmath>
+#include <iostream>
 #include <memory>
+#include <vector>
 
 using std::make_shared;
 

--- a/examples/DijkstraExample/dijkstra_example.cpp
+++ b/examples/DijkstraExample/dijkstra_example.cpp
@@ -1,4 +1,5 @@
 #include <CXXGraph/CXXGraph.hpp>
+#include <iostream>
 #include <memory>
 
 using std::make_shared;

--- a/examples/FloydWarshallExample/floyd_warshall.cpp
+++ b/examples/FloydWarshallExample/floyd_warshall.cpp
@@ -1,4 +1,5 @@
 #include <CXXGraph/CXXGraph.hpp>
+#include <iostream>
 #include <memory>
 
 using std::make_shared;

--- a/examples/PartitionExample/partition_example.cpp
+++ b/examples/PartitionExample/partition_example.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <ctime>
-#include <iterator>
+#include <iostream>
+#include <string>
 
 #include "CXXGraph/CXXGraph.hpp"
 

--- a/examples/PrimExample/prim_example.cpp
+++ b/examples/PrimExample/prim_example.cpp
@@ -1,4 +1,5 @@
 #include <CXXGraph/CXXGraph.hpp>
+#include <iostream>
 #include <memory>
 
 using std::make_shared;

--- a/include/CXXGraph/Edge/DirectedEdge_decl.h
+++ b/include/CXXGraph/Edge/DirectedEdge_decl.h
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "Edge_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Edge/DirectedEdge_impl.hpp
+++ b/include/CXXGraph/Edge/DirectedEdge_impl.hpp
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <string>
+#include <utility>
+
 #include "DirectedEdge_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Edge/DirectedWeightedEdge_decl.h
+++ b/include/CXXGraph/Edge/DirectedWeightedEdge_decl.h
@@ -21,6 +21,10 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "DirectedEdge_decl.h"
 #include "Weighted.h"
 

--- a/include/CXXGraph/Edge/DirectedWeightedEdge_impl.hpp
+++ b/include/CXXGraph/Edge/DirectedWeightedEdge_impl.hpp
@@ -21,6 +21,9 @@
 
 #pragma once
 
+#include <string>
+#include <utility>
+
 #include "DirectedWeightedEdge_decl.h"
 #include "Weighted.h"
 

--- a/include/CXXGraph/Edge/Edge_decl.h
+++ b/include/CXXGraph/Edge/Edge_decl.h
@@ -24,6 +24,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 
 #include "CXXGraph/Node/Node.h"

--- a/include/CXXGraph/Edge/Edge_impl.hpp
+++ b/include/CXXGraph/Edge/Edge_impl.hpp
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "CXXGraph/Edge/Edge_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Edge/UndirectedEdge_decl.h
+++ b/include/CXXGraph/Edge/UndirectedEdge_decl.h
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "Edge_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Edge/UndirectedEdge_impl.hpp
+++ b/include/CXXGraph/Edge/UndirectedEdge_impl.hpp
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <string>
+#include <utility>
+
 #include "UndirectedEdge_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Edge/UndirectedWeightedEdge_decl.h
+++ b/include/CXXGraph/Edge/UndirectedWeightedEdge_decl.h
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "UndirectedEdge_decl.h"
 #include "Weighted.h"
 

--- a/include/CXXGraph/Edge/UndirectedWeightedEdge_impl.hpp
+++ b/include/CXXGraph/Edge/UndirectedWeightedEdge_impl.hpp
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <string>
+#include <utility>
+
 #include "UndirectedWeightedEdge_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BellmanFord_impl.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <algorithm>
+#include <unordered_map>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BestFirstSearch_impl.hpp
@@ -25,9 +25,13 @@
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/Boruvka_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Boruvka_impl.hpp
@@ -24,6 +24,8 @@
 
 #include <limits.h>
 
+#include <unordered_map>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BreadthFirstSearch_impl.hpp
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <algorithm>
+#include <queue>
+#include <vector>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/BronKerbosch_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/BronKerbosch_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/Connectivity_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Connectivity_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/CycleDetection_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/CycleDetection_impl.hpp
@@ -23,6 +23,10 @@
 #pragma once
 
 #include <algorithm>
+#include <memory>
+#include <queue>
+#include <unordered_map>
+#include <vector>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/DepthFirstSearch_impl.hpp
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <algorithm>
+#include <memory>
+#include <vector>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/Dial_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dial_impl.hpp
@@ -23,6 +23,10 @@
 #pragma once
 
 #include <algorithm>
+#include <deque>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Dijkstra_impl.hpp
@@ -23,6 +23,12 @@
 #pragma once
 
 #include <algorithm>
+#include <map>
+#include <queue>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/EulerianPath_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/EulerianPath_impl.hpp
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/FloydWarshall_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/FloydWarshall_impl.hpp
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include <string>
+#include <unordered_map>
+#include <utility>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/FordFulkerson_impl.hpp
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <algorithm>
+#include <queue>
+#include <unordered_map>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/HopcroftKarp_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/HopcroftKarp_impl.hpp
@@ -24,6 +24,9 @@
 
 #include <iostream>
 #include <queue>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/Kahn_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Kahn_impl.hpp
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <queue>
+#include <unordered_map>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/Kosaraju_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Kosaraju_impl.hpp
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <stack>
+#include <unordered_map>
+#include <utility>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 

--- a/include/CXXGraph/Graph/Algorithm/Kruskal_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Kruskal_impl.hpp
@@ -22,6 +22,11 @@
 
 #pragma once
 
+#include <queue>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/Prim_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Prim_impl.hpp
@@ -22,6 +22,12 @@
 
 #pragma once
 
+#include <queue>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/Tarjan_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/Tarjan_impl.hpp
@@ -22,6 +22,11 @@
 
 #pragma once
 
+#include <stack>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/TopologicalSort_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/TopologicalSort_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/TransitiveReduction_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/TransitiveReduction_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Algorithm/WelshPowellColoring_impl.hpp
+++ b/include/CXXGraph/Graph/Algorithm/WelshPowellColoring_impl.hpp
@@ -7,6 +7,11 @@
 
 #pragma once
 
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/Graph_decl.h
+++ b/include/CXXGraph/Graph/Graph_decl.h
@@ -36,6 +36,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "CXXGraph/Edge/DirectedEdge.h"
 #include "CXXGraph/Edge/DirectedWeightedEdge.h"

--- a/include/CXXGraph/Graph/Graph_impl.hpp
+++ b/include/CXXGraph/Graph/Graph_impl.hpp
@@ -24,6 +24,12 @@
 
 #include <algorithm>
 #include <deque>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "CXXGraph/Graph/Graph_decl.h"
 #include "CXXGraph/Utility/ConstString.hpp"

--- a/include/CXXGraph/Graph/IO/IOUtility_impl.hpp
+++ b/include/CXXGraph/Graph/IO/IOUtility_impl.hpp
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/IO/InputOperation_impl.hpp
+++ b/include/CXXGraph/Graph/IO/InputOperation_impl.hpp
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include <string>
+#include <unordered_map>
+#include <utility>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/IO/OutputOperation_impl.hpp
+++ b/include/CXXGraph/Graph/IO/OutputOperation_impl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "CXXGraph/Graph/Graph_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Node/Node_decl.h
+++ b/include/CXXGraph/Node/Node_decl.h
@@ -22,6 +22,7 @@
 
 #pragma once
 #include <iostream>
+#include <string>
 
 #include "CXXGraph/Utility/id_t.hpp"
 

--- a/include/CXXGraph/Node/Node_impl.hpp
+++ b/include/CXXGraph/Node/Node_impl.hpp
@@ -21,6 +21,7 @@
 #define __CXXGRAPH_NODE_IMPL_H__
 
 #include <iomanip>
+#include <string>
 
 #include "Node_decl.h"
 

--- a/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <algorithm>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <set>

--- a/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedRecord.hpp
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <algorithm>
+#include <memory>
+#include <mutex>
 #include <set>
 
 #include "CXXGraph/Utility/Typedef.hpp"

--- a/include/CXXGraph/Partitioning/EBV.hpp
+++ b/include/CXXGraph/Partitioning/EBV.hpp
@@ -20,10 +20,12 @@
 #ifndef __CXXGRAPH_PARTITIONING_EBV_H__
 #define __CXXGRAPH_PARTITIONING_EBV_H__
 
-#include <memory>
 #pragma once
 
 #include <chrono>
+#include <cmath>
+#include <map>
+#include <memory>
 #include <unordered_map>
 
 #include "CXXGraph/Edge/Edge.h"

--- a/include/CXXGraph/Partitioning/EdgeBalancedVertexCut.hpp
+++ b/include/CXXGraph/Partitioning/EdgeBalancedVertexCut.hpp
@@ -20,10 +20,11 @@
 #ifndef __CXXGRAPH_PARTITIONING_EDGEBALANCEDVERTEXCUT_H__
 #define __CXXGRAPH_PARTITIONING_EDGEBALANCEDVERTEXCUT_H__
 
-#include <memory>
 #pragma once
 
 #include <chrono>
+#include <cmath>
+#include <memory>
 
 #include "CXXGraph/Edge/Edge.h"
 #include "CXXGraph/Partitioning/Utility/Globals.hpp"

--- a/include/CXXGraph/Partitioning/GreedyVertexCut.hpp
+++ b/include/CXXGraph/Partitioning/GreedyVertexCut.hpp
@@ -20,13 +20,17 @@
 #ifndef __CXXGRAPH_PARTITIONING_GREEDYVERTEXCUT_H__
 #define __CXXGRAPH_PARTITIONING_GREEDYVERTEXCUT_H__
 
-#include <memory>
 #pragma once
 
 #include <limits.h>
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
+#include <memory>
 #include <random>
+#include <set>
+#include <vector>
 
 #include "CXXGraph/Edge/Edge.h"
 #include "CXXGraph/Partitioning/Utility/Globals.hpp"

--- a/include/CXXGraph/Partitioning/HDRF.hpp
+++ b/include/CXXGraph/Partitioning/HDRF.hpp
@@ -20,11 +20,12 @@
 #ifndef __CXXGRAPH_PARTITIONING_HDRF_H__
 #define __CXXGRAPH_PARTITIONING_HDRF_H__
 
-#include <memory>
 #pragma once
 
 #include <chrono>
+#include <memory>
 #include <random>
+#include <vector>
 
 #include "CXXGraph/Edge/Edge.h"
 #include "CXXGraph/Partitioning/Utility/Globals.hpp"

--- a/include/CXXGraph/Partitioning/PartitionState.hpp
+++ b/include/CXXGraph/Partitioning/PartitionState.hpp
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <memory>
+#include <set>
+#include <vector>
 
 #include "Record.hpp"
 

--- a/include/CXXGraph/Partitioning/PartitionStrategy.hpp
+++ b/include/CXXGraph/Partitioning/PartitionStrategy.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "CXXGraph/Edge/Edge.h"
 #include "PartitionState.hpp"
 

--- a/include/CXXGraph/Partitioning/Partitioner.hpp
+++ b/include/CXXGraph/Partitioning/Partitioner.hpp
@@ -20,8 +20,10 @@
 #ifndef __CXXGRAPH_PARTITIONING_PARTITIONER_H__
 #define __CXXGRAPH_PARTITIONING_PARTITIONER_H__
 
-#include <memory>
 #pragma once
+
+#include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include "CXXGraph/Edge/Edge.h"

--- a/include/CXXGraph/Partitioning/Utility/Globals.hpp
+++ b/include/CXXGraph/Partitioning/Utility/Globals.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <iostream>
+#include <string>
 #include <thread>
 
 #include "CXXGraph/Partitioning/PartitionAlgorithm.hpp"

--- a/include/CXXGraph/Partitioning/WeightBalancedLibra.hpp
+++ b/include/CXXGraph/Partitioning/WeightBalancedLibra.hpp
@@ -23,6 +23,10 @@
 #pragma once
 
 #include <chrono>
+#include <cmath>
+#include <memory>
+#include <set>
+#include <unordered_map>
 
 #include "CXXGraph/Edge/Edge.h"
 #include "CXXGraph/Partitioning/Utility/Globals.hpp"

--- a/include/CXXGraph/Utility/Reader.hpp
+++ b/include/CXXGraph/Utility/Reader.hpp
@@ -22,6 +22,8 @@
 
 #pragma once  // This is to make sure that this header is only included once
 
+#include <fstream>
+
 namespace CXXGraph {
 // Foward declaration
 template <typename T>

--- a/include/CXXGraph/Utility/Typedef.hpp
+++ b/include/CXXGraph/Utility/Typedef.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "ConstValue.hpp"

--- a/include/CXXGraph/Utility/Writer.hpp
+++ b/include/CXXGraph/Utility/Writer.hpp
@@ -22,6 +22,8 @@
 
 #pragma once  // This is to make sure that this header is only included once
 
+#include <fstream>
+
 namespace CXXGraph {
 
 template <typename T>

--- a/test/BFSTest.cpp
+++ b/test/BFSTest.cpp
@@ -1,4 +1,8 @@
+#include <memory>
 #include <random>
+#include <set>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "CXXGraph/CXXGraph.hpp"

--- a/test/BinaryIOTest.cpp
+++ b/test/BinaryIOTest.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/DFSTest.cpp
+++ b/test/DFSTest.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <vector>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/DialTest.cpp
+++ b/test/DialTest.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/DijkstraTest.cpp
+++ b/test/DijkstraTest.cpp
@@ -1,4 +1,6 @@
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/DirectedEdgeTest.cpp
+++ b/test/DirectedEdgeTest.cpp
@@ -1,15 +1,6 @@
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"
 
-// Smart pointers alias
-template <typename T>
-using unique = std::unique_ptr<T>;
-template <typename T>
-using shared = std::shared_ptr<T>;
-
-using std::make_shared;
-using std::make_unique;
-
 TEST(DirectedEdgeTest, Constructor_1) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);

--- a/test/DirectedWeightedEdgeTest.cpp
+++ b/test/DirectedWeightedEdgeTest.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"
 

--- a/test/EdgeTest.cpp
+++ b/test/EdgeTest.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"
 

--- a/test/FWTest.cpp
+++ b/test/FWTest.cpp
@@ -1,5 +1,7 @@
 #include <map>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/GraphSlicingTest.cpp
+++ b/test/GraphSlicingTest.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <vector>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -1,5 +1,6 @@
-
+#include <map>
 #include <memory>
+#include <string>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/HopcroftKarpTest.cpp
+++ b/test/HopcroftKarpTest.cpp
@@ -1,4 +1,6 @@
 #include <memory>
+#include <set>
+#include <string>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/KahnTest.cpp
+++ b/test/KahnTest.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <unordered_map>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/NodeTest.cpp
+++ b/test/NodeTest.cpp
@@ -1,3 +1,8 @@
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"
 

--- a/test/RWOutputTest.cpp
+++ b/test/RWOutputTest.cpp
@@ -1,6 +1,8 @@
 #include <fstream>
 #include <memory>
 #include <optional>
+#include <string>
+#include <unordered_map>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "CXXGraph/Utility/SecureRandom.hpp"

--- a/test/TarjanTest.cpp
+++ b/test/TarjanTest.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <random>
 #include <vector>
 
@@ -5,8 +6,6 @@
 #include "gtest/gtest.h"
 
 // Smart pointers alias
-template <typename T>
-using unique = std::unique_ptr<T>;
 template <typename T>
 using shared = std::shared_ptr<T>;
 

--- a/test/TopologicalSortTest.cpp
+++ b/test/TopologicalSortTest.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <unordered_map>
 
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"

--- a/test/UndirectedEdgeTest.cpp
+++ b/test/UndirectedEdgeTest.cpp
@@ -1,15 +1,6 @@
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"
 
-// Smart pointers alias
-template <typename T>
-using unique = std::unique_ptr<T>;
-template <typename T>
-using shared = std::shared_ptr<T>;
-
-using std::make_shared;
-using std::make_unique;
-
 TEST(UndirectedEdgeTest, Constructor_1) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);

--- a/test/UndirectedWeightedEdgeTest.cpp
+++ b/test/UndirectedWeightedEdgeTest.cpp
@@ -1,15 +1,6 @@
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"
 
-// Smart pointers alias
-template <typename T>
-using unique = std::unique_ptr<T>;
-template <typename T>
-using shared = std::shared_ptr<T>;
-
-using std::make_shared;
-using std::make_unique;
-
 TEST(UndirectedWeightedEdgeTest, Constructor_1) {
   CXXGraph::Node<int> node1("1", 1);
   CXXGraph::Node<int> node2("2", 2);

--- a/test/UnionFindTest.cpp
+++ b/test/UnionFindTest.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+#include <unordered_map>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"
 

--- a/test/Utilities.hpp
+++ b/test/Utilities.hpp
@@ -1,6 +1,7 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
 #include <ctime>
+#include <map>
 #include <memory>
 #include <random>
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "CXXGraph/CXXGraph.hpp"
 #include "gtest/gtest.h"
 /*************** EXAMPLE START   ********************


### PR DESCRIPTION
This is makes the code less dependent on transitive includes.

Since the change is quite big, I decided to cut it into smaller pieces. This PR addresses all of the standard headers. I am planning to create another PR with CXXGraph headers only.