### PR TITLE
Add missing include statements

### DIFF
--- a/include/CXXGraph/Edge/UndirectedEdge_decl.h
+++ b/include/CXXGraph/Edge/UndirectedEdge_decl.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <utility>
 
+#include "DirectedEdge_decl.h"
 #include "Edge_decl.h"
 
 namespace CXXGraph {

--- a/include/CXXGraph/Graph/IO/InputOperation_impl.hpp
+++ b/include/CXXGraph/Graph/IO/InputOperation_impl.hpp
@@ -27,6 +27,7 @@
 #include <utility>
 
 #include "CXXGraph/Graph/Graph_decl.h"
+#include "IOUtility_impl.hpp"
 
 namespace CXXGraph {
 

--- a/include/CXXGraph/Partitioning/PartitionState.hpp
+++ b/include/CXXGraph/Partitioning/PartitionState.hpp
@@ -26,6 +26,7 @@
 #include <set>
 #include <vector>
 
+#include "CXXGraph/Edge/Edge_decl.h"
 #include "CXXGraph/Utility/id_t.hpp"
 #include "Record.hpp"
 


### PR DESCRIPTION
Now all of the headers compile on their own.

Continuation #560 and #561.