### PR TITLE
Add g++ and clang++ warnings and treat them as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ else ()
 			-fsanitize=leak
 		)
 	endif(SANITIZE)
+  add_compile_options(
+    -Werror
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-unused-parameter
+  )
 endif(MSVC)
 
 # set up CPM.cmake

--- a/benchmark/Utilities.hpp
+++ b/benchmark/Utilities.hpp
@@ -1,5 +1,6 @@
 #ifndef __UTILITIES_H__
 #define __UTILITIES_H__
+#include <cassert>
 #include <ctime>
 #include <map>
 #include <random>
@@ -81,6 +82,7 @@ static CXXGraph::Graph<int> *readGraph(const std::string &filename) {
   auto result =
       graph_ptr->readFromFile(CXXGraph::InputOutputFormat::STANDARD_CSV,
                               "../benchmark/dataset", filename);
+  assert(result == 0);
   return graph_ptr;
 }
 

--- a/examples/PartitionExample/partition_example.cpp
+++ b/examples/PartitionExample/partition_example.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
@@ -10,6 +11,7 @@ static CXXGraph::Graph<int> *readGraph(const std::string &filename) {
   auto result =
       graph_ptr->readFromFile(CXXGraph::InputOutputFormat::STANDARD_CSV,
                               "../../../benchmark/dataset", filename);
+  assert(result == 0);
   return graph_ptr;
 }
 


### PR DESCRIPTION
This PR makes the clang++/g++ compiler slightly more strict. `unused-parameter` is suppressed because of
https://github.com/ZigRazor/CXXGraph/blob/8be1dcbd609625f8053106d492dfca7bddb7f85e/include/CXXGraph/Graph/IO/InputOperation_impl.hpp#L35-L38

I am planning to make a similar PR for MSVC.
