### PR TITLE
Add msvc warnings and treat them as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,16 @@ endif(DEBUG)
 
 if (MSVC)
 	add_compile_options(/bigobj)
+  add_compile_options(
+    /WX
+    /W4
+    /permissive-
+    /wd4127
+    /wd4244
+    /wd4456
+    /wd4458
+    /wd4459
+  )
 else ()
 	option(SANITIZE "Enable Sanitize" OFF)
 	if(SANITIZE)


### PR DESCRIPTION
Similar to #568.

- C4127 needed to be disabled in order to [build `zlib`](https://github.com/ZigRazor/CXXGraph/actions/runs/20214168204/job/58024514164?pr=572),
-   C4244, C4456, C4458, C4459 needed to be disabled due to [CXXGraph code](https://github.com/ZigRazor/CXXGraph/actions/runs/20214210704/job/58024618837).