### PR TITLE
Mark some of the single argument constructors as `explicit`

### DIFF
--- a/include/CXXGraph/Edge/DirectedWeightedEdge_decl.h
+++ b/include/CXXGraph/Edge/DirectedWeightedEdge_decl.h
@@ -63,7 +63,7 @@ class DirectedWeightedEdge : public DirectedEdge<T>, public Weighted {
       const double weight);
   DirectedWeightedEdge(const DirectedEdge<T> &edge, const double weight);
   DirectedWeightedEdge(const Edge<T> &edge, const double weight);
-  DirectedWeightedEdge(const DirectedEdge<T> &edge);
+  explicit DirectedWeightedEdge(const DirectedEdge<T> &edge);
   DirectedWeightedEdge(const Edge<T> &edge);
   DirectedWeightedEdge(const UndirectedWeightedEdge<T> &edge);
   ~DirectedWeightedEdge() override = default;

--- a/include/CXXGraph/Edge/UndirectedWeightedEdge_decl.h
+++ b/include/CXXGraph/Edge/UndirectedWeightedEdge_decl.h
@@ -65,7 +65,7 @@ class UndirectedWeightedEdge : public UndirectedEdge<T>, public Weighted {
       const double weight);
   UndirectedWeightedEdge(const UndirectedEdge<T> &edge, const double weight);
   UndirectedWeightedEdge(const Edge<T> &edge, const double weight);
-  UndirectedWeightedEdge(const UndirectedEdge<T> &edge);
+  explicit UndirectedWeightedEdge(const UndirectedEdge<T> &edge);
   UndirectedWeightedEdge(const Edge<T> &edge);
   UndirectedWeightedEdge(const DirectedWeightedEdge<T> &edge);
   ~UndirectedWeightedEdge() override = default;

--- a/include/CXXGraph/Graph/Graph_decl.h
+++ b/include/CXXGraph/Graph/Graph_decl.h
@@ -204,7 +204,7 @@ class Graph {
 
  public:
   Graph();
-  Graph(const T_EdgeSet<T> &edgeSet);
+  explicit Graph(const T_EdgeSet<T> &edgeSet);
   virtual ~Graph() = default;
 
   /**

--- a/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
+++ b/include/CXXGraph/Partitioning/CoordinatedPartitionState.hpp
@@ -62,7 +62,7 @@ class CoordinatedPartitionState : public PartitionState<T> {
   std::shared_ptr<std::mutex> record_map_mutex = nullptr;
   // DatWriter out; //to print the final partition of each edge
  public:
-  CoordinatedPartitionState(const Globals &G);
+  explicit CoordinatedPartitionState(const Globals &G);
   ~CoordinatedPartitionState() override;
 
   std::shared_ptr<Record<T>> getRecord(CXXGraph::id_t x) override;

--- a/include/CXXGraph/Partitioning/Utility/Globals.hpp
+++ b/include/CXXGraph/Partitioning/Utility/Globals.hpp
@@ -33,11 +33,11 @@ namespace Partitioning {
 class Globals {
  private:
  public:
-  Globals(const int numberOfPartiton,
-          const PartitionAlgorithm algorithm = PartitionAlgorithm::HDRF_ALG,
-          const double param1 = 1, const double param2 = 1,
-          const double param3 = 1,
-          const unsigned int threads = std::thread::hardware_concurrency());
+  explicit Globals(
+      const int numberOfPartiton,
+      const PartitionAlgorithm algorithm = PartitionAlgorithm::HDRF_ALG,
+      const double param1 = 1, const double param2 = 1, const double param3 = 1,
+      const unsigned int threads = std::thread::hardware_concurrency());
   ~Globals();
 
   const std::string print() const;


### PR DESCRIPTION
This PR marks some of the single argument constructors as `explicit` (cf. [`google-explicit-constructor`](https://clang.llvm.org/extra/clang-tidy/checks/google/explicit-constructor.html)).

The remaining ones:
- https://github.com/ZigRazor/CXXGraph/blob/ce504fc1e079c5c332a8feb46b60361b3bbb73b7/include/CXXGraph/Edge/DirectedEdge_decl.h#L58
- https://github.com/ZigRazor/CXXGraph/blob/ce504fc1e079c5c332a8feb46b60361b3bbb73b7/include/CXXGraph/Edge/DirectedWeightedEdge_decl.h#L67
- https://github.com/ZigRazor/CXXGraph/blob/ce504fc1e079c5c332a8feb46b60361b3bbb73b7/include/CXXGraph/Edge/DirectedWeightedEdge_decl.h#L68
- https://github.com/ZigRazor/CXXGraph/blob/ce504fc1e079c5c332a8feb46b60361b3bbb73b7/include/CXXGraph/Edge/UndirectedEdge_decl.h#L58
- https://github.com/ZigRazor/CXXGraph/blob/ce504fc1e079c5c332a8feb46b60361b3bbb73b7/include/CXXGraph/Edge/UndirectedWeightedEdge_decl.h#L69
- https://github.com/ZigRazor/CXXGraph/blob/ce504fc1e079c5c332a8feb46b60361b3bbb73b7/include/CXXGraph/Edge/UndirectedWeightedEdge_decl.h#L70

require mote attention (simple addition of `explicit` cases build errors or even test errors).

Happy new year!